### PR TITLE
Add SCT and dcm2niix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,84 @@
 
 Repository containing pipeline for processing spinal cord injury (SCI) patients (both DCM and tSCI) using the [Spinal Cord Toolbox (SCT)](https://github.com/spinalcordtoolbox/spinalcordtoolbox).
 
-Steps:
+Pipeline steps:
 1. DICOM to nii (BIDS) conversion
 2. Processing (spinal cord and lesion segmentation, vertebral labeling)
 3. Quality control (QC) + manual compression level labeling
 4. Lesion metric computation
+
+
+## Dependencies
+
+[Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4)
+[dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install)
+
+## Installation
+
+### SCT Installation
+
+1. Open a new terminal:
+
+Press <kbd>command</kbd> + <kbd>space</kbd> and type `Terminal` and press <kbd>return/enter</kbd>.
+
+2. Run the following commands in the terminal (you can copy-paste the whole block):
+
+> [!NOTE]
+> The installation process will take a few minutes.
+
+```bash
+# Go to your home directory
+cd ~
+# Download SCT v6.4
+wget https://github.com/spinalcordtoolbox/spinalcordtoolbox/archive/refs/tags/6.4.zip
+# Unzip the downloaded file --> the unzipped directory will be named spinalcordtoolbox-6.4
+unzip 6.4.zip
+rm 6.4.zip
+# Go to the SCT directory
+cd spinalcordtoolbox-6.4
+# Install SCT v6.4
+./install_sct -iyc
+#  '-i'   Install in-place; this is the default when working from git.
+#  '-y'   Install without interruption with 'yes' as default answer
+#  '-c'   Disables sct_check_dependencies so we can check it separately
+```
+
+> [!NOTE]
+> We are not using `git clone` because Apple Developer Tools are needed for `git`.
+
+3. Check that SCT was installed correctly:
+
+Close the terminal and open a new one (press <kbd>command</kbd> + <kbd>space</kbd> and type `Terminal` and press <kbd>return/enter</kbd>.).
+
+```bash
+sct_check_dependencies
+echo $SCT_DIR
+```
+
+The expected output is `[OK]` for all dependencies.
+
+### dcm2niix Installation
+
+1. Open a new terminal (if you closed the previous one):
+
+Press <kbd>command</kbd> + <kbd>space</kbd> and type `Terminal` and press <kbd>return/enter</kbd>.
+
+2. Run the following commands in the terminal (you can copy-paste the whole block):
+
+```bash
+# Go to the SCT directory
+cd $SCT_DIR
+# Activate SCT conda environment
+source ./python/etc/profile.d/conda.sh
+conda activate venv_sct
+# Install dcm2niix using pip
+pip install dcm2niix
+```
+
+3. Check that `dcm2niix` was installed correctly:
+
+```bash
+dcm2niix --version
+```
+
+The expected output is the version of `dcm2niix`.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ rm 6.4.zip
 cd spinalcordtoolbox-6.4
 # Install SCT v6.4
 ./install_sct -iyc
-#  '-i'   Install in-place; this is the default when working from git.
+#  '-i'   Install in-place (i.e., in the current directory)
 #  '-y'   Install without interruption with 'yes' as default answer
 #  '-c'   Disables sct_check_dependencies so we can check it separately
 ```

--- a/README.md
+++ b/README.md
@@ -8,15 +8,20 @@ Pipeline steps:
 3. Quality control (QC) + manual compression level labeling
 4. Lesion metric computation
 
+## Table of contents
+* [1. Dependencies](#1-dependencies)
+* [2. Installation](#2-installation)
+  * [2.1 SCT Installation](#21-sct-installation)
+  * [2.2 dcm2niix Installation](#22-dcm2niix-installation)
 
-## Dependencies
+## 1. Dependencies
 
 [Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4)
 [dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install)
 
-## Installation
+## 2. Installation
 
-### SCT Installation
+### 2.1 SCT Installation
 
 1. Open a new terminal:
 
@@ -58,7 +63,7 @@ echo $SCT_DIR
 
 The expected output is `[OK]` for all dependencies.
 
-### dcm2niix Installation
+### 2.2 dcm2niix Installation
 
 1. Open a new terminal (if you closed the previous one):
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Pipeline steps:
 
 ## 2. Installation
 
+> [!NOTE]
+> The installation process below is currently only supported on macOS.
+
 ### 2.1 SCT Installation
 
 1. Open a new terminal:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Pipeline steps:
 * [2. Installation](#2-installation)
   * [2.1 SCT Installation](#21-sct-installation)
   * [2.2 dcm2niix Installation](#22-dcm2niix-installation)
+* [3. Processing pipeline](#3-processing-pipeline)
 
 ## 1. Dependencies
 
@@ -93,3 +94,7 @@ dcm2niix --version
 ```
 
 The expected output is the version of `dcm2niix`.
+
+## 3. Processing pipeline
+
+TODO

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ cd spinalcordtoolbox-6.4
 Close the terminal and open a new one (press <kbd>command</kbd> + <kbd>space</kbd> and type `Terminal` and press <kbd>return/enter</kbd>.).
 
 ```bash
+# Check that SCT was installed correctly
 sct_check_dependencies
+# Display location of SCT installation
 echo $SCT_DIR
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Pipeline steps:
 
 ## 1. Dependencies
 
-[Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4)
-[dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install)
+* [Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4)
+* [dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install)
 
 ## 2. Installation
 


### PR DESCRIPTION
This PR adds instructions on how to install SCT and dcm2niix.

As discussed in https://github.com/sct-pipeline/balgrist-sci/issues/1, we opted to describe the installation process in README (instead of having an "installation script").

Link to the README: https://github.com/sct-pipeline/balgrist-sci/blob/jv/add_installation_instructions/README.md

Related: https://github.com/sct-pipeline/balgrist-sci/issues/1