### PR TITLE
Add `File organization` and `DICOM to NIfTI conversion` sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Pipeline steps:
 * [2. Installation](#2-installation)
   * [2.1 SCT Installation](#21-sct-installation)
   * [2.2 dcm2niix Installation](#22-dcm2niix-installation)
+  * [2.3 Downloading this repository](#23-downloading-this-repository)
 * [3. Data structure](#3-data-structure)
   * [3.1 File organization](#31-file-organization)
   * [3.2 DICOM to NIfTI conversion](#32-dicom-to-nifti-conversion)
@@ -98,6 +99,37 @@ dcm2niix --version
 ```
 
 The expected output is the version of `dcm2niix`.
+
+</details>
+
+### 2.3 Downloading this repository
+
+<details><summary>Click the triangle to expand/collapse the section</summary>
+
+1. Open a new terminal (if you closed the previous one):
+
+Press <kbd>command</kbd> + <kbd>space</kbd> and type `Terminal` and press <kbd>return/enter</kbd>.
+
+2. Run the following commands in the terminal (you can copy-paste the whole block):
+
+```bash
+# Go to your home directory
+cd ~
+# Download (clone) the repository --> the repository will be downloaded to a directory named balgrist-sci
+git clone https://github.com/sct-pipeline/balgrist-sci.git balgrist-sci
+```
+
+TODO: Replace `git clone` by `wget` once we publish a repo release because Apple Developer Tools are needed for `git`.
+
+3. Check that the repository was downloaded correctly:
+
+```bash
+# Activate SCT conda environment
+source ./python/etc/profile.d/conda.sh
+conda activate venv_sct
+# Call the help of the file_loader.py script
+python ~/balgrist-sci/file_loader.py --help
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -167,3 +167,18 @@ The rest of the directories and files will be created during the processing; see
 ℹ️ Notice that we use one row per session. This means that, for example, `sub-001` has two rows in the table because they have two sessions.
 
 </details>
+
+### 3.2 DICOM to NIfTI conversion
+
+A single subject DICOM images can be converted to NIfTI and organized according to the BIDS standard using 
+the `file_loader.py` script.
+
+Example usage:
+
+```bash
+python ~/code/balgrist-sci/file_loader.py \
+  -dicom-folder ~/data/experiments/balgrist-sci/source_data/dir_20231010 \
+  -bids-folder ~/data/experiments/balgrist-sci/bids \ 
+  -participant sub-001 \
+  -session ses-01 
+```

--- a/README.md
+++ b/README.md
@@ -116,24 +116,30 @@ The rest of the directories and files will be created during the processing.
 │   ├── ... 
 │   ├── dir_20240815        --> folder with DICOM files for first subject and second session
 │   └── ... 
-├── sub-001                 --> folder containing NIfTI files for first subject
-│   ├── ses-01              --> first session
-│   │  ├── anat             --> folder with anatomical data
-│   │  │  ├── sub-001_ses-01_T2w.nii.gz
-│   │  │  ├── sub-001_ses-01_T2w_copression.nii.gz
-│   │  │  ├── ...
-│   │  └── dwi              --> folder with diffusion data
-│   │     ├── sub-001_ses-01_dwi.nii.gz
-│   │     ├── sub-001_ses-01_dwi.bval
-│   │     ├── sub-001_ses-01_dwi.bvec
-│   └── ses-02              --> second session
-│      ├── ...
-├── sub-002                 --> folder containing NIfTI files for second subject
-│   ├── ...
-├── ...
+├── bids                    --> folder with BIDS-compliant data
+│    ├── sub-001            --> folder containing NIfTI files for first subject
+│    │   ├── ses-01         --> first session
+│    │   │  ├── anat        --> folder with anatomical data
+│    │   │  │  ├── sub-001_ses-01_T1w.nii.gz
+│    │   │  │  ├── sub-001_ses-01_T2w.nii.gz
+│    │   │  │  ├── ...
+│    │   │  └── dwi         --> folder with diffusion data
+│    │   │     ├── sub-001_ses-01_dwi.nii.gz
+│    │   │     ├── sub-001_ses-01_dwi.bval
+│    │   │     ├── sub-001_ses-01_dwi.bvec
+│    │   └── ses-02         --> second session
+│    │      ├── ...
+│    ├── sub-002            --> folder containing NIfTI files for second subject
+│    │   ├── ...
+│    ├── ...
+├── data_processed          --> folder with processed data  
+│    ├── sub-001            --> folder with processed data for first subject
+│    │   ├── ses-01         --> first session
+│    │   │  ├── anat        --> folder with processed anatomical data
+│    │   │  │  ├── ...
 └── derivatives             --> folder to store visually checked and/or manually corrected data (for example, spinal cord segmentations)
     └── labels
-        ├── sub-001         --> folder with corrected data for first subject
+        ├── sub-001         --> first subject
         │   ├── ses-01      --> first session
         │   │  ├── anat
         │   │  │  ├── sub-001_ses-01_T2w_label-SC_seg.nii.gz              --> spinal cord (SC) binary segmentation 

--- a/README.md
+++ b/README.md
@@ -9,26 +9,29 @@ Steps:
 4. Lesion metric computation
 
 ## Table of contents
-* [1. Dependencies](#1-dependencies)
-* [2. Installation](#2-installation)
-  * [2.1 SCT Installation](#21-sct-installation)
-  * [2.2 dcm2niix Installation](#22-dcm2niix-installation)
-  * [2.3 Downloading this repository](#23-downloading-this-repository)
-* [3. Data structure](#3-data-structure)
-  * [3.1 File organization](#31-file-organization)
-  * [3.2 DICOM to NIfTI conversion](#32-dicom-to-nifti-conversion)
+- [1. Getting Started](#1-getting-started)
+  - [1.1 Dependencies](#11-dependencies)
+  - [1.2 Installation](#12-installation)
+    - [SCT Installation](#sct-installation)
+    - [dcm2niix Installation](#dcm2niix-installation)
+    - [Downloading this repository](#downloading-this-repository)
+- [2. Data structure](#2-data-structure)
+  - [2.1 File organization](#21-file-organization)
+  - [2.2 DICOM to NIfTI conversion](#22-dicom-to-nifti-conversion)
 
-## 1. Dependencies
+## 1. Getting Started
+
+### 1.1 Dependencies
 
 * [Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4): toolbox for processing spinal cord MRI data
 * [dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install): tool for converting DICOM images into the NIfTI format
 
-## 2. Installation
+### 1.2 Installation
 
 > [!NOTE]
 > The installation process below is currently only supported on macOS.
 
-### 2.1 SCT Installation
+#### SCT Installation
 
 <details><summary>Click the triangle to expand/collapse the section</summary>
 
@@ -72,7 +75,7 @@ The expected output is `[OK]` for all dependencies.
 
 </details>
 
-### 2.2 dcm2niix Installation
+#### dcm2niix Installation
 
 <details><summary>Click the triangle to expand/collapse the section</summary>
 
@@ -102,7 +105,7 @@ The expected output is the version of `dcm2niix`.
 
 </details>
 
-### 2.3 Downloading this repository
+#### Downloading this repository
 
 <details><summary>Click the triangle to expand/collapse the section</summary>
 
@@ -133,9 +136,9 @@ python ~/balgrist-sci/file_loader.py --help
 
 </details>
 
-## 3. Data structure
+## 2. Data structure
 
-### 3.1 File organization
+### 2.1 File organization
 
 <details><summary>Click the triangle to expand/collapse the section</summary>
 
@@ -202,7 +205,7 @@ The rest of the directories and files will be created during the processing; see
 
 </details>
 
-### 3.2 DICOM to NIfTI conversion
+### 2.2 DICOM to NIfTI conversion
 
 A single subject DICOM images can be converted to NIfTI and organized according to the BIDS standard using 
 the `file_loader.py` script.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Pipeline steps:
 
 ## 1. Dependencies
 
-* [Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4)
-* [dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install)
+* [Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4): the toolbox for processing spinal cord MRI data
+* [dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install): a tool for converting DICOM images into the NIfTI format
 
 ## 2. Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Pipeline steps:
 * [2. Installation](#2-installation)
   * [2.1 SCT Installation](#21-sct-installation)
   * [2.2 dcm2niix Installation](#22-dcm2niix-installation)
-* [3. Processing pipeline](#3-processing-pipeline)
+* [3. Data structure](#3-data-structure)
 
 ## 1. Dependencies
 
@@ -99,6 +99,49 @@ The expected output is the version of `dcm2niix`.
 
 </details>
 
-## 3. Processing pipeline
+## 3. Data structure
 
-TODO
+<details><summary>Click the triangle to expand/collapse the section</summary>
+
+Expected data structure compliant with the [BIDS standard](https://bids-specification.readthedocs.io/en/stable/):
+
+```
+├── sourcedata              --> folder containing DICOM files for each subject
+│   ├── dir_20230711        --> folder with DICOM files for first subject and first session
+│   ├── dir_20230711        --> folder with DICOM files for second subject and first session
+│   ├── ... 
+│   ├── dir_20240815        --> folder with DICOM files for first subject and second session
+│   └── ... 
+├── sub-001                 --> folder containing NIfTI files for first subject
+│   ├── ses-01              --> first session
+│   │  ├── anat             --> folder with anatomical data
+│   │  │  ├── sub-001_ses-01_T2w.nii.gz
+│   │  │  ├── sub-001_ses-01_T2w_copression.nii.gz
+│   │  │  ├── ...
+│   │  └── dwi              --> folder with diffusion data
+│   │     ├── sub-001_ses-01_dwi.nii.gz
+│   │     ├── sub-001_ses-01_dwi.bval
+│   │     ├── sub-001_ses-01_dwi.bvec
+│   └── ses-02              --> second session
+│      ├── ...
+├── sub-002                 --> folder containing NIfTI files for second subject
+│   ├── ...
+├── ...
+└── derivatives             --> folder to store visually checked and/or manually corrected data (for example, spinal cord segmentations)
+    └── labels
+        ├── sub-001         --> folder with corrected data for first subject
+        │   ├── ses-01      --> first session
+        │   │  ├── anat
+        │   │  │  ├── sub-001_ses-01_T2w_label-SC_seg.nii.gz              --> spinal cord (SC) binary segmentation 
+        │   │  │  ├── sub-001_ses-01_T2w_label-compression_label.nii.gz   --> binary compression labeling
+        │   │  │  ├── ...
+        │   │  └── dwi
+        │   │     ├── sub-001_ses-01_dwi_label-SC_seg.nii.gz
+        │   │     ├── ...
+        │   └── ses-02      --> second session
+        │      ├── ...
+        ├── sub-002 
+        └── ...
+```
+
+</details>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ The expected output is the version of `dcm2niix`.
 
 <details><summary>Click the triangle to expand/collapse the section</summary>
 
-Expected data structure compliant with the [BIDS standard](https://bids-specification.readthedocs.io/en/stable/):
+Expected data structure compliant with the [BIDS standard](https://bids-specification.readthedocs.io/en/stable/) is shown below.
+
+Note that only the `sourcedata` directory containing folders with DICOM files for each subject is required. 
+The rest of the directories and files will be created during the processing.
 
 ```
 ├── sourcedata              --> folder containing DICOM files for each subject

--- a/README.md
+++ b/README.md
@@ -214,5 +214,6 @@ python ~/balgrist-sci/file_loader.py \
   -dicom-folder ~/data/experiments/balgrist-sci/source_data/dir_20231010 \
   -bids-folder ~/data/experiments/balgrist-sci/bids \ 
   -participant sub-001 \
-  -session ses-01 
+  -session ses-01 \
+  -contrasts T2w dwi
 ```

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ The expected output is the version of `dcm2niix`.
 
 <details><summary>Click the triangle to expand/collapse the section</summary>
 
-Expected data structure compliant with the [BIDS standard](https://bids-specification.readthedocs.io/en/stable/) is shown below.
+Expected [BIDS](https://bids-specification.readthedocs.io/en/stable/)-like structures is shown below.
 
 Note that only the `sourcedata` directory containing folders with DICOM files for each subject is required. 
 The rest of the directories and files will be created during the processing.
 
 ```
-├── participants.tsv        --> file with participant information; see example below
+├── participants.tsv        --> file with participants information; see example below
 ├── sourcedata              --> folder containing DICOM files for each subject
 │   ├── dir_20230711        --> folder with DICOM files for first subject and first session
 │   ├── dir_20230711        --> folder with DICOM files for second subject and first session

--- a/README.md
+++ b/README.md
@@ -101,12 +101,14 @@ The expected output is the version of `dcm2niix`.
 
 ## 3. Data structure
 
+### 3.1 File organization
+
 <details><summary>Click the triangle to expand/collapse the section</summary>
 
-Expected [BIDS](https://bids-specification.readthedocs.io/en/stable/)-like structures is shown below.
+A file organization according to the [BIDS](https://bids-specification.readthedocs.io/en/stable/) is shown below.
 
-Note that only the `sourcedata` directory containing folders with DICOM files for each subject is required. 
-The rest of the directories and files will be created during the processing.
+Note that only the `sourcedata` directory containing folders with DICOM files for each subject is initially required. 
+The rest of the directories and files will be created during the processing; see the next section.
 
 ```
 ├── participants.tsv        --> file with participants information; see example below

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Note that only the `sourcedata` directory containing folders with DICOM files fo
 The rest of the directories and files will be created during the processing.
 
 ```
+├── participants.tsv        --> file with participant information; see example below
 ├── sourcedata              --> folder containing DICOM files for each subject
 │   ├── dir_20230711        --> folder with DICOM files for first subject and first session
 │   ├── dir_20230711        --> folder with DICOM files for second subject and first session
@@ -146,5 +147,15 @@ The rest of the directories and files will be created during the processing.
         ├── sub-002 
         └── ...
 ```
+
+`participants.tsv` example:
+
+| participant_id | ses_id | source_id | age | sex |
+|----------------|--------|-----------|-----|-----|
+| sub-01         | ses-01 | dir_20230711 | 42  | M   |
+| sub-01         | ses-02 | dir_20240815 | 43  | M   |
+| sub-02         | ses-01 | dir_20230713 | 57  | F   |
+
+ℹ️ Notice that we use one row per session. This means that, for example, `sub-01` has two rows in the table because they have two sessions.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ the `file_loader.py` script.
 Example usage:
 
 ```bash
-python ~/code/balgrist-sci/file_loader.py \
+python ~/balgrist-sci/file_loader.py \
   -dicom-folder ~/data/experiments/balgrist-sci/source_data/dir_20231010 \
   -bids-folder ~/data/experiments/balgrist-sci/bids \ 
   -participant sub-001 \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # balgrist-sci
 
-Repository containing pipeline for processing spinal cord injury (SCI) patients (both DCM and tSCI) using the [Spinal Cord Toolbox (SCT)](https://github.com/spinalcordtoolbox/spinalcordtoolbox).
+Repository containing code to process MRI data from spinal cord injury (SCI) patients (both DCM and tSCI) using the [Spinal Cord Toolbox (SCT)](https://github.com/spinalcordtoolbox/spinalcordtoolbox).
 
-Pipeline steps:
-1. DICOM to nii (BIDS) conversion
+Steps:
+1. DICOM to NIfTI (BIDS) conversion
 2. Processing (spinal cord and lesion segmentation, vertebral labeling)
 3. Quality control (QC) + manual compression level labeling
 4. Lesion metric computation
@@ -210,6 +210,11 @@ the `file_loader.py` script.
 Example usage:
 
 ```bash
+# Activate SCT conda environment
+cd $SCT_DIR
+source ./python/etc/profile.d/conda.sh
+conda activate venv_sct
+# Run the script
 python ~/balgrist-sci/file_loader.py \
   -dicom-folder ~/data/experiments/balgrist-sci/source_data/dir_20231010 \
   -bids-folder ~/data/experiments/balgrist-sci/bids \ 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Pipeline steps:
 
 ## 1. Dependencies
 
-* [Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4): the toolbox for processing spinal cord MRI data
-* [dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install): a tool for converting DICOM images into the NIfTI format
+* [Spinal Cord Toolbox v6.4](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.4): toolbox for processing spinal cord MRI data
+* [dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install): tool for converting DICOM images into the NIfTI format
 
 ## 2. Installation
 

--- a/README.md
+++ b/README.md
@@ -152,10 +152,10 @@ The rest of the directories and files will be created during the processing.
 
 | participant_id | ses_id | source_id | age | sex |
 |----------------|--------|-----------|-----|-----|
-| sub-01         | ses-01 | dir_20230711 | 42  | M   |
-| sub-01         | ses-02 | dir_20240815 | 43  | M   |
-| sub-02         | ses-01 | dir_20230713 | 57  | F   |
+| sub-001        | ses-01 | dir_20230711 | 42  | M   |
+| sub-001        | ses-02 | dir_20240815 | 43  | M   |
+| sub-002        | ses-01 | dir_20230713 | 57  | F   |
 
-ℹ️ Notice that we use one row per session. This means that, for example, `sub-01` has two rows in the table because they have two sessions.
+ℹ️ Notice that we use one row per session. This means that, for example, `sub-001` has two rows in the table because they have two sessions.
 
 </details>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Pipeline steps:
   * [2.1 SCT Installation](#21-sct-installation)
   * [2.2 dcm2niix Installation](#22-dcm2niix-installation)
 * [3. Data structure](#3-data-structure)
+  * [3.1 File organization](#31-file-organization)
+  * [3.2 DICOM to NIfTI conversion](#32-dicom-to-nifti-conversion)
 
 ## 1. Dependencies
 

--- a/file_loader.py
+++ b/file_loader.py
@@ -152,7 +152,8 @@ def select_image(contrast, nii_info_df, temp_folder):
     # Ask the user to provide a row number (df index) corresponding to the image
     while True:
         time.sleep(0.5)
-        row_number = int(input(f"Please specify the row number of the {contrast} image you want to use: "))
+        row_number = int(input(f"Please specify the row number (from 0 to {len(nii_info_df)-1}) of the {contrast} "
+                               f"image you want to use: "))
         if row_number < 0 or row_number >= len(nii_info_df):
             logging.info("Warning: Invalid image number. Please try again.")
             continue

--- a/file_loader.py
+++ b/file_loader.py
@@ -213,7 +213,7 @@ def get_nii_info_dataframe(temp_folder):
     df = pd.DataFrame({
         'File Name': file_names,
         'Dimensions': dimensions_list,
-        'Pixel Size': pixel_sizes
+        'Pixel Size [mm]': pixel_sizes
     })
 
     return df
@@ -297,6 +297,7 @@ def main():
 
     nii_info_df = get_nii_info_dataframe(temp_folder)
     # Display the DataFrame
+    pd.set_option('display.max_colwidth', None)
     print(f'{nii_info_df}\n')
 
     # Select images intended for further processing

--- a/file_loader.py
+++ b/file_loader.py
@@ -92,6 +92,13 @@ def get_parser():
         type=list,
         required=False
     )
+    parser.add_argument(
+        "-debug",
+        help="If used, the temporary folder with NIfTI images will NOT be removed.",
+        action="store_true",
+        default=False,
+        required=False
+    )
 
     return parser.parse_args()
 
@@ -302,9 +309,12 @@ def main():
         print(f"Copying {contrast} image to the BIDS folder.")
         copy_files_to_bids_folder(contrast, fname, output_folder, participant_id, session_id)
 
-    # Lastly, remove the temporary folder
-    print("\nInfo: Removing the temporary folder {temp_folder}")
-    shutil.rmtree(os.path.join(output_folder, "temp_dcm2niix"))
+    if args.debug:
+        print(f"\nInfo: Temporary folder with NIfTI images is stored in: {temp_folder}")
+    # Remove the temporary folder
+    else:
+        print(f"\nInfo: Removing the temporary folder {temp_folder}")
+        shutil.rmtree(temp_folder)
 
     print(100*"-")
     print("All files have been successfully converted and validated. You can find the following images in the "

--- a/file_loader.py
+++ b/file_loader.py
@@ -68,7 +68,8 @@ def get_parser():
     argparse.Namespace: Parsed arguments
     """
     parser = argparse.ArgumentParser(
-        description="Convert DICOM to NIfTI and identify images for the further analysis."
+        description="Convert DICOM to NIfTI and identify images for the further analysis.",
+        formatter_class=argparse.RawTextHelpFormatter
     )
     parser.add_argument(
         "-dicom-folder",

--- a/file_loader.py
+++ b/file_loader.py
@@ -95,7 +95,9 @@ def get_parser():
     )
     parser.add_argument(
         "-contrasts",
-        help="MRI contrasts to use. Example: T2w dwi",
+        help="MRI contrasts to use. Separate multiple contrasts with a space. Example: 'T2w dwi'\n"
+             "To distinguish between two images of the same contrast with different orientation, use the 'acq' tag, "
+             "for example: 'acq-axial_T2w acq-sag_T2w'",
         nargs='+',
         default=["T2w", "dwi"],
         required=False

--- a/file_loader.py
+++ b/file_loader.py
@@ -8,6 +8,9 @@ Namely, the script:
     - checks for .bval and .bvec files for DWI image
     - provides information about the images' dimensions and pixel sizes
 
+Requirements:
+    - dcm2niix -- see the Installation section in the README.md file
+
 Author: Jan Valosek and Claude 3.5 Sonnet
 """
 import os

--- a/file_loader.py
+++ b/file_loader.py
@@ -56,8 +56,7 @@ def get_image_info(file_path):
     """
     Get the dimensions and pixel size of the image at the given file path.
 
-    Args:
-    file_path (str): Path to the image file.
+    :param file_path: Path to the image file
     """
     img = nib.load(file_path)
     zooms = img.header.get_zooms()
@@ -137,6 +136,12 @@ def validate_dwi_image(fname):
 
 
 def get_nii_info_dataframe(temp_folder):
+    """
+    Get the information about the NIfTI images in the temporary folder and store it in a DataFrame.
+
+    :param temp_folder: Path to the temporary folder with NIfTI images
+    :return: DataFrame with image information
+    """
     # Get all nii files in the temporary folder
     nii_files = [f for f in os.listdir(temp_folder) if f.endswith('.nii.gz')]
 

--- a/file_loader.py
+++ b/file_loader.py
@@ -72,12 +72,8 @@ def run_dcm2niix(dicom_folder, temp_folder):
     """
     Run dcm2niix command to convert DICOM images to NIfTI format.
 
-    Args:
-    dicom_folder (str): Path to the folder containing DICOM images.
-    temp_folder (str): Path to the temporary folder for NIfTI images.
-
-    Returns:
-    tuple: Paths to the converted T2w and DWI NIfTI files.
+    :param dicom_folder: Path to the folder containing DICOM images.
+    :param temp_folder: Path to the temporary folder where the NIfTI images will be stored.
     """
 
     cmd = [

--- a/file_loader.py
+++ b/file_loader.py
@@ -40,6 +40,11 @@ Output file structure:
 
 Author: Jan Valosek and Claude 3.5 Sonnet
 """
+
+# TODO: write a new entry to the participant.tsv file based on the provided information (add sex and age args?)
+# TODO: use logging instead of print statements
+
+
 import os
 import shutil
 import argparse

--- a/file_loader.py
+++ b/file_loader.py
@@ -197,6 +197,9 @@ def get_nii_info_dataframe(temp_folder):
     # Get all nii files in the temporary folder
     nii_files = [f for f in os.listdir(temp_folder) if f.endswith('.nii.gz')]
 
+    # Sort nii files based on the series number (the last number in the file name before the .nii.gz extension)
+    nii_files.sort(key=lambda x: int(x.split('_')[-1].split('.')[0]))
+
     # Create lists to store the information
     file_names = []
     dimensions_list = []

--- a/file_loader.py
+++ b/file_loader.py
@@ -49,6 +49,15 @@ def get_parser():
         help="Session ID. Example: ses-01",
         required=True
     )
+    parser.add_argument(
+        "-contrasts",
+        help="MRI contrasts to use. Example: T2w dwi",
+        nargs='+',
+        default=["T2w", "dwi"],
+        type=list,
+        required=False
+    )
+
     return parser.parse_args()
 
 
@@ -208,6 +217,7 @@ def main():
     bids_folder = os.path.expanduser(args.bids_folder)
     participant_id = args.participant
     session_id = args.session
+    contrasts = args.contrasts
 
     print(100*"-")
     print(f'Dicom folder: {dicom_folder}')
@@ -249,7 +259,7 @@ def main():
 
     # Select images intended for further processing
     images_to_use_dict = {}
-    for contrast in ["T2w", "dwi"]:
+    for contrast in contrasts:
         images_to_use_dict[contrast] = select_image(contrast, nii_info_df, temp_folder)
 
     # Copy the files to the BIDS folder

--- a/file_loader.py
+++ b/file_loader.py
@@ -342,13 +342,12 @@ def main():
         ]
     )
 
-    logging.info(f"Log file created at: {log_filepath}")
-
     logging.info(100*"-")
     logging.info(f'Dicom folder: {dicom_folder}')
     logging.info(f'BIDS folder: {bids_folder}')
     logging.info(f'Participant ID: {participant_id}')
     logging.info(f'Session ID: {session_id}')
+    logging.info(f"Log file will be stored in: {log_filepath}")
     logging.info(100*"-")
 
     # Check if the folder with DICOMs exists

--- a/file_loader.py
+++ b/file_loader.py
@@ -129,6 +129,8 @@ def run_dcm2niix(dicom_folder, output_folder):
         dicom_folder
     ]
 
+    print("\nInfo: Starting DICOM to NIfTI conversion using dcm2niix.\n")
+
     os.system(" ".join(cmd))
 
 
@@ -248,6 +250,7 @@ def main():
     else:
         # Create the output folder if it does not exist
         os.makedirs(output_folder, exist_ok=True)
+        print(f"\nInfo: Converted NIfTI images will be stored in: {output_folder}")
 
     # Run DICOM to NIfTI conversion using the dcm2niix command
     run_dcm2niix(dicom_folder, output_folder)

--- a/file_loader.py
+++ b/file_loader.py
@@ -198,6 +198,11 @@ def get_nii_info_dataframe(temp_folder):
     # Get all nii files in the temporary folder
     nii_files = [f for f in os.listdir(temp_folder) if f.endswith('.nii.gz')]
 
+    # Check if there are any NIfTI files in the folder, if not, print error message and exit
+    if not nii_files:
+        logging.error("Error: No NIfTI files found in the temporary folder.")
+        exit(1)
+
     # Sort nii files based on the series number (the last number in the file name before the .nii.gz extension)
     nii_files.sort(key=lambda x: int(x.split('_')[-1].split('.')[0]))
 

--- a/file_loader.py
+++ b/file_loader.py
@@ -89,7 +89,6 @@ def get_parser():
         help="MRI contrasts to use. Example: T2w dwi",
         nargs='+',
         default=["T2w", "dwi"],
-        type=list,
         required=False
     )
     parser.add_argument(

--- a/file_loader.py
+++ b/file_loader.py
@@ -154,7 +154,7 @@ def select_image(contrast, nii_info_df, temp_folder):
         time.sleep(0.5)
         row_number = int(input(f"Please specify the row number of the {contrast} image you want to use: "))
         if row_number < 0 or row_number >= len(nii_info_df):
-            logging.error("Invalid image number. Please try again.")
+            logging.info("Warning: Invalid image number. Please try again.")
             continue
         else:
             fname = nii_info_df.iloc[row_number]['File Name']
@@ -180,8 +180,8 @@ def validate_dwi_image(fname):
 
     # Check whether both bval and bvec files exist (we need them for DWI processing)
     if not os.path.isfile(fname_bval) or not os.path.isfile(fname_bvec):
-        logging.error("bval or bvec file is missing for the provided DWI image."
-                      "\nPlease try another DWI image.")
+        logging.info("Warning: bval or bvec file is missing for the provided DWI image."
+                     "\nPlease try another DWI image.")
         return False
     else:
         return True

--- a/file_loader.py
+++ b/file_loader.py
@@ -241,6 +241,7 @@ def copy_files_to_bids_folder(contrast, fname, output_folder, participant_id, se
 
     # Second, move the images and JSON sidecars to the respective folders
     fname_output = os.path.join(output_folder, f"{participant_id}_{session_id}_{contrast}.nii.gz")
+    print(f"Info: Copying {fname} to {fname_output}")
     shutil.copy(fname, fname_output)
     shutil.copy(fname.replace('.nii.gz', '.json'), fname_output.replace('.nii.gz', '.json'))
     # For DWI, we also need to copy the bval and bvec files
@@ -305,8 +306,8 @@ def main():
         images_to_use_dict[contrast] = select_image(contrast, nii_info_df, temp_folder)
 
     # Copy the files to the BIDS folder
+    print('')
     for contrast, fname in images_to_use_dict.items():
-        print(f"Copying {contrast} image to the BIDS folder.")
         copy_files_to_bids_folder(contrast, fname, output_folder, participant_id, session_id)
 
     if args.debug:

--- a/file_loader.py
+++ b/file_loader.py
@@ -11,6 +11,33 @@ Namely, the script:
 Requirements:
     - dcm2niix -- see the Installation section in the README.md file
 
+Input file structure:
+
+    └── source_data
+        └── dir_20231010
+            ├── MRc.1.3.12.2.543543
+            ├── ...
+            └── SRe. 1.3.12.2.5432233
+
+Output file structure:
+
+    ├── bids
+    │   └── sub-001
+    │       └── ses-01
+    │           ├── anat
+    │           │   ├── sub-001_ses-01_T2w.json
+    │           │   └── sub-001_ses-01_T2w.nii.gz
+    │           └── dwi
+    │               ├── sub-001_ses-01_dwi.bval
+    │               ├── sub-001_ses-01_dwi.bvec
+    │               ├── sub-001_ses-01_dwi.json
+    │               └── sub-001_ses-01_dwi.nii.gz
+    └── source_data
+        └── dir_20231010
+            ├── MRc.1.3.12.2.543543
+            ├── ...
+            └── SRe. 1.3.12.2.5432233
+
 Author: Jan Valosek and Claude 3.5 Sonnet
 """
 import os

--- a/file_loader.py
+++ b/file_loader.py
@@ -1,0 +1,255 @@
+"""
+This python script provides interactive prompts for users to retry input if files are not found or if the image
+information is not as expected.
+
+Namely, the script:
+    - allow users to specify paths for T2w and DWI images
+    - validates file existence
+    - checks for .bval and .bvec files for DWI image
+    - provides information about the images' dimensions and pixel sizes
+
+Author: Jan Valosek and Claude 3.5 Sonnet
+"""
+import os
+import shutil
+import subprocess
+import argparse
+import nibabel as nib
+
+
+def get_parser():
+    """
+    Parse command-line arguments.
+
+    Returns:
+    argparse.Namespace: Parsed arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Convert DICOM to NIfTI and identify images for the further analysis."
+    )
+    parser.add_argument(
+        "-dicom-folder",
+        help="Path to the folder containing DICOM images. Example: ~/sci-balgrist-study/sourcedata/dir_20230711",
+        required=True
+    )
+    parser.add_argument(
+        "-participant",
+        help="Participant ID. Example: sub-001",
+        required=True
+    )
+    parser.add_argument(
+        "-session",
+        help="Session ID. Example: ses-01",
+        required=True
+    )
+    return parser.parse_args()
+
+
+def get_valid_file_path(prompt):
+    """
+    Repeatedly prompt the user for a file path until a valid file is specified or the user aborts.
+
+    Args:
+    prompt (str): The input prompt to display to the user.
+
+    Returns:
+    str: The valid file path.
+    """
+    while True:
+        file_path = input(prompt)
+        # Get absolute path, expand user path
+        file_path = os.path.abspath(os.path.expanduser(file_path))
+        if os.path.isfile(file_path):
+            return file_path
+        print(f"Error: File does not exist: {file_path}"
+              f"\nPlease try again.")
+
+
+def print_image_info(file_path):
+    """
+    Print the dimensions and pixel size of the image at the given file path.
+
+    Args:
+    file_path (str): Path to the image file.
+    """
+    img = nib.load(file_path)
+    zooms = img.header.get_zooms()
+    print(f"Dimensions: {img.shape[0]} x {img.shape[1]} x {img.shape[2]}")
+    print(f"Pixel size: {zooms[0]:.2f} mm x {zooms[1]:.2f} mm x {zooms[2]:.2f} mm")
+
+
+def confirm_image_info(file_path):
+    """
+    Display the image dimensions and pixel size and ask the user to confirm if it's correct.
+
+    Args:
+    file_path (str): Path to the image file.
+
+    Returns:
+    bool: True if the user confirms the information, False otherwise.
+    """
+    while True:
+        print_image_info(file_path)
+        confirm = input("Do you agree with this image info? (y/n): ").lower()
+        if confirm in ['y', 'yes', 'Y', 'YES']:
+            return True
+        elif confirm in ['n', 'no', 'N', 'NO']:
+            return False
+        else:
+            print("Invalid input. Please enter 'y' or 'n'.")
+
+
+def run_dcm2niix(dicom_folder, output_folder):
+    """
+    Run dcm2niix command to convert DICOM images to NIfTI format.
+
+    Args:
+    dicom_folder (str): Path to the folder containing DICOM images.
+    output_folder (str): Path to the output folder for NIfTI images.
+
+    Returns:
+    tuple: Paths to the converted T2w and DWI NIfTI files.
+    """
+    # Create a temporary output folder to store dcm2niix output before renaming the files
+    temp_folder = os.path.join(output_folder, "temp_dcm2niix")
+    os.makedirs(temp_folder, exist_ok=True)
+
+    cmd = [
+        "dcm2niix",
+        "-z", "y",          # Compress output
+        "-f", "%f_%p_%s",   # Custom filename format: %f - folder name, %p - protocol name, %s - series number
+        "-i", "y",          # Ignore derived, localizer and 2D images
+        "-o", temp_folder,
+        dicom_folder
+    ]
+
+    os.system(" ".join(cmd))
+
+
+def get_t2_image_path():
+    """
+    Get the path to the T2w image and check the image information.
+
+    Returns:
+    str: Valid T2w image path.
+    """
+    print(10*"-")
+    print("T2w image")
+    print(10*"-")
+    # Get T2w image path
+    while True:
+        t2w_path = get_valid_file_path("Please specify the path to the T2w image: ")
+
+        # If the image info is confirmed, return the image path
+        if confirm_image_info(t2w_path):
+            return t2w_path
+        print("Let's try another T2w image.")
+
+
+def get_dwi_image_path():
+    """
+    Get the path to the DWI image and check for the existence of bval and bvec files.
+
+    Returns:
+    str: Valid DWI image path.
+    """
+    print(10*"-")
+    print("DWI image")
+    print(10*"-")
+    # Get DWI image path
+    while True:
+        # Ask the user for the DWI image path
+        dwi_path = get_valid_file_path("Please specify the path to the DWI image: ")
+
+        # Check for bval and bvec files
+        dwi_base = dwi_path.replace('.nii', '').replace('.gz', '')
+        bval_path = f"{dwi_base}.bval"
+        bvec_path = f"{dwi_base}.bvec"
+
+        # Check whether both bval and bvec files exist (we need them for DWI processing to compute DTI model)
+        if not os.path.isfile(bval_path) or not os.path.isfile(bvec_path):
+            print("Error: bval or bvec file is missing for the provided DWI image."
+                  "\nPlease try another DWI image.")
+            continue
+        else:
+            print("bval and bvec files found.")
+
+        # If the image info is confirmed, return the image path
+        if confirm_image_info(dwi_path):
+            return dwi_path
+        print("Let's try another DWI image.")
+
+
+def copy_files_to_bids_folder(output_folder, participant_id, session_id, t2w_path, dwi_path):
+    """
+    Copy the converted nii images from the temporary folder to the output BIDS folder
+    :param output_folder: temporary folder with the converted nii images
+    :param participant_id: participant ID, e.g., sub-001
+    :param session_id: session ID, e.g., ses-01
+    :param t2w_path: path to the T2w image provided by the user
+    :param dwi_path: path to the DWI image provided by the user
+    """
+    # First, create anat and dwi subfolders if they do not exist
+    output_folder_anat = os.path.join(output_folder, "anat")
+    os.makedirs(output_folder_anat, exist_ok=True)
+    output_folder_dwi = os.path.join(output_folder, "dwi")
+    os.makedirs(output_folder_dwi, exist_ok=True)
+
+    # Second, move the images and JSON sidecars to the respective folders
+    t2w_path_output = os.path.join(output_folder_anat, f"{participant_id}_{session_id}_T2w.nii.gz")
+    dwi_path_output = os.path.join(output_folder_dwi, f"{participant_id}_{session_id}_dwi.nii.gz")
+    shutil.copy(t2w_path, t2w_path_output)
+    shutil.copy(t2w_path.replace('.nii.gz', '.json'), t2w_path_output.replace('.nii.gz', '.json'))
+    # For DWI, we also need to copy the bval and bvec files
+    shutil.copy(dwi_path, dwi_path_output)
+    shutil.copy(dwi_path.replace('.nii.gz', '.json'), dwi_path_output.replace('.nii.gz', '.json'))
+    shutil.copy(dwi_path.replace('.nii.gz', '.bval'), dwi_path_output.replace('.nii.gz', '.bval'))
+    shutil.copy(dwi_path.replace('.nii.gz', '.bvec'), dwi_path_output.replace('.nii.gz', '.bvec'))
+
+    # Lastly, remove the temporary folder
+    shutil.rmtree(os.path.join(output_folder, "temp_dcm2niix"))
+
+
+def main():
+    """
+    Main function
+    """
+    args = get_parser()
+
+    dicom_folder = args.dicom_folder
+    participant_id = args.participant
+    session_id = args.session
+
+    print(100*"-")
+    print(f'Dicom folder: {dicom_folder}')
+    print(f'Participant ID: {participant_id}')
+    print(f'Session ID: {session_id}')
+    print(100*"-")
+
+    # Check if the folder with DICOMs exists
+    if not os.path.isdir(dicom_folder):
+        print(f"Error: Provided folder with DICOM images does not exist: {args.dicom_folder}")
+        exit(1)
+
+    # Run DICOM to NIfTI conversion using the dcm2niix command
+    output_folder = os.path.join(os.path.dirname(args.dicom_folder), "bids", participant_id, session_id)
+    # Create the output folder if it does not exist
+    os.makedirs(output_folder, exist_ok=True)
+    run_dcm2niix(dicom_folder, output_folder)
+
+    print(100*"-")
+    print("DICOM to NIfTI is done. Please review the images and provide paths to the T2w and DWI images.")
+    print(100*"-")
+
+    # Get the paths to the converted T2w and DWI images
+    t2w_path = get_t2_image_path()
+    dwi_path = get_dwi_image_path()
+
+    # Copy the files to the BIDS folder
+    copy_files_to_bids_folder(output_folder, participant_id, session_id, t2w_path, dwi_path)
+
+    print("\nAll files have been successfully validated and confirmed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/file_loader.py
+++ b/file_loader.py
@@ -167,10 +167,10 @@ def get_dwi_image_path():
     # Get DWI image path
     while True:
         # Ask the user for the DWI image path
-        dwi_path = get_valid_file_path("Please specify the path to the DWI image: ")
+        path_dwi = get_valid_file_path("Please specify the path to the DWI image: ")
 
         # Check for bval and bvec files
-        dwi_base = dwi_path.replace('.nii', '').replace('.gz', '')
+        dwi_base = path_dwi.replace('.nii', '').replace('.gz', '')
         bval_path = f"{dwi_base}.bval"
         bvec_path = f"{dwi_base}.bvec"
 
@@ -183,19 +183,19 @@ def get_dwi_image_path():
             print("bval and bvec files found.")
 
         # If the image info is confirmed, return the image path
-        if confirm_image_info(dwi_path):
-            return dwi_path
+        if confirm_image_info(path_dwi):
+            return path_dwi
         print("Let's try another DWI image.")
 
 
-def copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2w, dwi_path):
+def copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2w, path_dwi):
     """
     Copy the converted nii images from the temporary folder to the output BIDS folder
     :param output_folder: temporary folder with the converted nii images
     :param participant_id: participant ID, e.g., sub-001
     :param session_id: session ID, e.g., ses-01
     :param path_t2w: path to the T2w image provided by the user
-    :param dwi_path: path to the DWI image provided by the user
+    :param path_dwi: path to the DWI image provided by the user
     """
     # First, create anat and dwi subfolders if they do not exist
     output_folder_anat = os.path.join(output_folder, "anat")
@@ -205,14 +205,14 @@ def copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2
 
     # Second, move the images and JSON sidecars to the respective folders
     path_t2w_output = os.path.join(output_folder_anat, f"{participant_id}_{session_id}_T2w.nii.gz")
-    dwi_path_output = os.path.join(output_folder_dwi, f"{participant_id}_{session_id}_dwi.nii.gz")
+    path_dwi_output = os.path.join(output_folder_dwi, f"{participant_id}_{session_id}_dwi.nii.gz")
     shutil.copy(path_t2w, path_t2w_output)
     shutil.copy(path_t2w.replace('.nii.gz', '.json'), path_t2w_output.replace('.nii.gz', '.json'))
     # For DWI, we also need to copy the bval and bvec files
-    shutil.copy(dwi_path, dwi_path_output)
-    shutil.copy(dwi_path.replace('.nii.gz', '.json'), dwi_path_output.replace('.nii.gz', '.json'))
-    shutil.copy(dwi_path.replace('.nii.gz', '.bval'), dwi_path_output.replace('.nii.gz', '.bval'))
-    shutil.copy(dwi_path.replace('.nii.gz', '.bvec'), dwi_path_output.replace('.nii.gz', '.bvec'))
+    shutil.copy(path_dwi, path_dwi_output)
+    shutil.copy(path_dwi.replace('.nii.gz', '.json'), path_dwi_output.replace('.nii.gz', '.json'))
+    shutil.copy(path_dwi.replace('.nii.gz', '.bval'), path_dwi_output.replace('.nii.gz', '.bval'))
+    shutil.copy(path_dwi.replace('.nii.gz', '.bvec'), path_dwi_output.replace('.nii.gz', '.bvec'))
 
     # Lastly, remove the temporary folder
     shutil.rmtree(os.path.join(output_folder, "temp_dcm2niix"))
@@ -261,10 +261,10 @@ def main():
 
     # Get the paths to the converted T2w and DWI images
     path_t2w = get_t2_image_path()
-    dwi_path = get_dwi_image_path()
+    path_dwi = get_dwi_image_path()
 
     # Copy the files to the BIDS folder
-    copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2w, dwi_path)
+    copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2w, path_dwi)
 
     print("\nAll files have been successfully validated and confirmed.")
 

--- a/file_loader.py
+++ b/file_loader.py
@@ -128,7 +128,7 @@ def run_dcm2niix(dicom_folder, temp_folder):
     cmd = [
         "dcm2niix",
         "-z", "y",      # Compress output
-        "-f", "%p_%s",  # Custom filename format: %p - protocol name, %s - series number
+        "-f", "%d_%p_%s",  # Custom filename format: %d - series description, %p - protocol name, %s - series number
         "-i", "y",      # Ignore derived, localizer and 2D images
         "-o", temp_folder,
         dicom_folder

--- a/file_loader.py
+++ b/file_loader.py
@@ -292,13 +292,13 @@ def main():
 
     # Check if the folder with DICOMs exists
     if not os.path.isdir(dicom_folder):
-        logging.error(f"Provided folder with DICOM images does not exist: {dicom_folder}")
+        logging.error(f"Error: Provided folder with DICOM images does not exist: {dicom_folder}")
         exit(1)
 
     # Check whether the BIDS folder already exists, if so, warn the user and exit
     output_folder = os.path.join(bids_folder, participant_id, session_id)
     if os.path.isdir(output_folder):
-        logging.error(f"BIDS folder for the provided participant and session already exists: {output_folder}"
+        logging.error(f"Error: BIDS folder for the provided participant and session already exists: {output_folder}"
                       f"\nPlease remove the existing BIDS folder and rerun the script.")
         exit(1)
     else:

--- a/file_loader.py
+++ b/file_loader.py
@@ -204,8 +204,8 @@ def main():
     """
     args = get_parser()
 
-    dicom_folder = args.dicom_folder
-    bids_folder = args.bids_folder
+    dicom_folder = os.path.expanduser(args.dicom_folder)
+    bids_folder = os.path.expanduser(args.bids_folder)
     participant_id = args.participant
     session_id = args.session
 

--- a/file_loader.py
+++ b/file_loader.py
@@ -1,5 +1,5 @@
 """
-Convert DICOM images to NIfTI format and identify images for the further analysis.
+Convert DICOM images to NIfTI format and identify images for further analysis.
 
 Namely, the script:
     - run dcm2niix command to convert DICOM images to NIfTI format

--- a/file_loader.py
+++ b/file_loader.py
@@ -146,11 +146,11 @@ def get_t2_image_path():
     print(10*"-")
     # Get T2w image path
     while True:
-        t2w_path = get_valid_file_path("Please specify the path to the T2w image: ")
+        path_t2w = get_valid_file_path("Please specify the path to the T2w image: ")
 
         # If the image info is confirmed, return the image path
-        if confirm_image_info(t2w_path):
-            return t2w_path
+        if confirm_image_info(path_t2w):
+            return path_t2w
         print("Let's try another T2w image.")
 
 
@@ -188,13 +188,13 @@ def get_dwi_image_path():
         print("Let's try another DWI image.")
 
 
-def copy_files_to_bids_folder(output_folder, participant_id, session_id, t2w_path, dwi_path):
+def copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2w, dwi_path):
     """
     Copy the converted nii images from the temporary folder to the output BIDS folder
     :param output_folder: temporary folder with the converted nii images
     :param participant_id: participant ID, e.g., sub-001
     :param session_id: session ID, e.g., ses-01
-    :param t2w_path: path to the T2w image provided by the user
+    :param path_t2w: path to the T2w image provided by the user
     :param dwi_path: path to the DWI image provided by the user
     """
     # First, create anat and dwi subfolders if they do not exist
@@ -204,10 +204,10 @@ def copy_files_to_bids_folder(output_folder, participant_id, session_id, t2w_pat
     os.makedirs(output_folder_dwi, exist_ok=True)
 
     # Second, move the images and JSON sidecars to the respective folders
-    t2w_path_output = os.path.join(output_folder_anat, f"{participant_id}_{session_id}_T2w.nii.gz")
+    path_t2w_output = os.path.join(output_folder_anat, f"{participant_id}_{session_id}_T2w.nii.gz")
     dwi_path_output = os.path.join(output_folder_dwi, f"{participant_id}_{session_id}_dwi.nii.gz")
-    shutil.copy(t2w_path, t2w_path_output)
-    shutil.copy(t2w_path.replace('.nii.gz', '.json'), t2w_path_output.replace('.nii.gz', '.json'))
+    shutil.copy(path_t2w, path_t2w_output)
+    shutil.copy(path_t2w.replace('.nii.gz', '.json'), path_t2w_output.replace('.nii.gz', '.json'))
     # For DWI, we also need to copy the bval and bvec files
     shutil.copy(dwi_path, dwi_path_output)
     shutil.copy(dwi_path.replace('.nii.gz', '.json'), dwi_path_output.replace('.nii.gz', '.json'))
@@ -260,11 +260,11 @@ def main():
     print(100*"-")
 
     # Get the paths to the converted T2w and DWI images
-    t2w_path = get_t2_image_path()
+    path_t2w = get_t2_image_path()
     dwi_path = get_dwi_image_path()
 
     # Copy the files to the BIDS folder
-    copy_files_to_bids_folder(output_folder, participant_id, session_id, t2w_path, dwi_path)
+    copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2w, dwi_path)
 
     print("\nAll files have been successfully validated and confirmed.")
 

--- a/file_loader.py
+++ b/file_loader.py
@@ -12,7 +12,6 @@ Author: Jan Valosek and Claude 3.5 Sonnet
 """
 import os
 import shutil
-import subprocess
 import argparse
 import nibabel as nib
 
@@ -29,7 +28,8 @@ def get_parser():
     )
     parser.add_argument(
         "-dicom-folder",
-        help="Path to the folder containing DICOM images. Example: ~/sci-balgrist-study/sourcedata/dir_20230711",
+        help="Path to the folder containing DICOM images. "
+             "Example: ~/sci-balgrist-study/sourcedata/dir_20230711",
         required=True
     )
     parser.add_argument(

--- a/file_loader.py
+++ b/file_loader.py
@@ -13,6 +13,7 @@ Author: Jan Valosek and Claude 3.5 Sonnet
 import os
 import shutil
 import argparse
+import pandas as pd
 import nibabel as nib
 
 
@@ -51,80 +52,39 @@ def get_parser():
     return parser.parse_args()
 
 
-def get_valid_file_path(prompt):
+def get_image_info(file_path):
     """
-    Repeatedly prompt the user for a file path until a valid file is specified or the user aborts.
-
-    Args:
-    prompt (str): The input prompt to display to the user.
-
-    Returns:
-    str: The valid file path.
-    """
-    while True:
-        file_path = input(prompt)
-        # Get absolute path, expand user path
-        file_path = os.path.abspath(os.path.expanduser(file_path))
-        if os.path.isfile(file_path):
-            return file_path
-        print(f"Error: File does not exist: {file_path}"
-              f"\nPlease try again.")
-
-
-def print_image_info(file_path):
-    """
-    Print the dimensions and pixel size of the image at the given file path.
+    Get the dimensions and pixel size of the image at the given file path.
 
     Args:
     file_path (str): Path to the image file.
     """
     img = nib.load(file_path)
     zooms = img.header.get_zooms()
-    print(f"Dimensions: {img.shape[0]} x {img.shape[1]} x {img.shape[2]}")
-    print(f"Pixel size: {zooms[0]:.2f} mm x {zooms[1]:.2f} mm x {zooms[2]:.2f} mm")
+
+    dimensions = f"{img.shape[0]} x {img.shape[1]} x {img.shape[2]}"
+    pixel_size = f"{zooms[0]:.2f} mm x {zooms[1]:.2f} mm x {zooms[2]:.2f} mm"
+
+    return dimensions, pixel_size
 
 
-def confirm_image_info(file_path):
-    """
-    Display the image dimensions and pixel size and ask the user to confirm if it's correct.
-
-    Args:
-    file_path (str): Path to the image file.
-
-    Returns:
-    bool: True if the user confirms the information, False otherwise.
-    """
-    while True:
-        print_image_info(file_path)
-        confirm = input("Do you agree with this image info? (y/n): ").lower()
-        if confirm in ['y', 'yes', 'Y', 'YES']:
-            return True
-        elif confirm in ['n', 'no', 'N', 'NO']:
-            return False
-        else:
-            print("Invalid input. Please enter 'y' or 'n'.")
-
-
-def run_dcm2niix(dicom_folder, output_folder):
+def run_dcm2niix(dicom_folder, temp_folder):
     """
     Run dcm2niix command to convert DICOM images to NIfTI format.
 
     Args:
     dicom_folder (str): Path to the folder containing DICOM images.
-    output_folder (str): Path to the output folder for NIfTI images.
+    temp_folder (str): Path to the temporary folder for NIfTI images.
 
     Returns:
     tuple: Paths to the converted T2w and DWI NIfTI files.
     """
-    # Create a temporary output folder to store dcm2niix output before renaming the files
-    temp_folder = os.path.join(output_folder, "temp_dcm2niix")
-    os.makedirs(temp_folder, exist_ok=True)
 
     cmd = [
         "dcm2niix",
-        "-z", "y",          # Compress output
-        "-f", "%f_%p_%s",   # Custom filename format: %f - folder name, %p - protocol name, %s - series number
-        "-i", "y",          # Ignore derived, localizer and 2D images
+        "-z", "y",      # Compress output
+        "-f", "%p_%s",  # Custom filename format: %p - protocol name, %s - series number
+        "-i", "y",      # Ignore derived, localizer and 2D images
         "-o", temp_folder,
         dicom_folder
     ]
@@ -134,88 +94,107 @@ def run_dcm2niix(dicom_folder, output_folder):
     os.system(" ".join(cmd))
 
 
-def get_t2_image_path():
+def select_image(contrast, nii_info_df, temp_folder):
     """
-    Get the path to the T2w image and check the image information.
+    Select an image from the list of images and return the selected image path.
 
-    Returns:
-    str: Valid T2w image path.
+    :param contrast: Contrast type, e.g., T2w, dwi
+    :param nii_info_df: DataFrame with image information
+    :param temp_folder: Path to the temporary folder with NIfTI images
+    :return: Path to the selected image
     """
-    print(10*"-")
-    print("T2w image")
-    print(10*"-")
-    # Get T2w image path
+    # Ask the user to provide a row number (df index) corresponding to the image
     while True:
-        path_t2w = get_valid_file_path("Please specify the path to the T2w image: ")
-
-        # If the image info is confirmed, return the image path
-        if confirm_image_info(path_t2w):
-            return path_t2w
-        print("Let's try another T2w image.")
-
-
-def get_dwi_image_path():
-    """
-    Get the path to the DWI image and check for the existence of bval and bvec files.
-
-    Returns:
-    str: Valid DWI image path.
-    """
-    print(10*"-")
-    print("DWI image")
-    print(10*"-")
-    # Get DWI image path
-    while True:
-        # Ask the user for the DWI image path
-        path_dwi = get_valid_file_path("Please specify the path to the DWI image: ")
-
-        # Check for bval and bvec files
-        dwi_base = path_dwi.replace('.nii', '').replace('.gz', '')
-        bval_path = f"{dwi_base}.bval"
-        bvec_path = f"{dwi_base}.bvec"
-
-        # Check whether both bval and bvec files exist (we need them for DWI processing to compute DTI model)
-        if not os.path.isfile(bval_path) or not os.path.isfile(bvec_path):
-            print("Error: bval or bvec file is missing for the provided DWI image."
-                  "\nPlease try another DWI image.")
+        row_number = int(input(f"Please specify the row number of the {contrast} image you want to use: "))
+        if row_number < 0 or row_number >= len(nii_info_df):
+            print("Error: Invalid image number. Please try again.")
             continue
         else:
-            print("bval and bvec files found.")
+            fname = nii_info_df.iloc[row_number]['File Name']
+            if contrast == "dwi":
+                if not validate_dwi_image(os.path.join(temp_folder, fname)):
+                    continue
 
-        # If the image info is confirmed, return the image path
-        if confirm_image_info(path_dwi):
-            return path_dwi
-        print("Let's try another DWI image.")
+            print(f"Selected {contrast} image: {fname}")
+            return os.path.join(temp_folder, fname)
 
 
-def copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2w, path_dwi):
+def validate_dwi_image(fname):
     """
-    Copy the converted nii images from the temporary folder to the output BIDS folder
+    Check the existence of bval and bvec files for the DWI image.
+
+    :param fname: DWI image file name
+    """
+
+    # Check for bval and bvec files
+    dwi_base = fname.replace('.nii', '').replace('.gz', '')
+    fname_bval = f"{dwi_base}.bval"
+    fname_bvec = f"{dwi_base}.bvec"
+
+    # Check whether both bval and bvec files exist (we need them for DWI processing)
+    if not os.path.isfile(fname_bval) or not os.path.isfile(fname_bvec):
+        print("Error: bval or bvec file is missing for the provided DWI image."
+              "\nPlease try another DWI image.")
+        return False
+    else:
+        return True
+
+
+def get_nii_info_dataframe(temp_folder):
+    # Get all nii files in the temporary folder
+    nii_files = [f for f in os.listdir(temp_folder) if f.endswith('.nii.gz')]
+
+    # Create lists to store the information
+    file_names = []
+    dimensions_list = []
+    pixel_sizes = []
+
+    # Collect information for each file
+    for nii_file in nii_files:
+        nii_path = os.path.join(temp_folder, nii_file)
+        dimensions, pixel_size = get_image_info(nii_path)
+
+        file_names.append(nii_file)
+        dimensions_list.append(dimensions)
+        pixel_sizes.append(pixel_size)
+
+    # Create a DataFrame
+    df = pd.DataFrame({
+        'File Name': file_names,
+        'Dimensions': dimensions_list,
+        'Pixel Size': pixel_sizes
+    })
+
+    return df
+
+
+def copy_files_to_bids_folder(contrast, fname, output_folder, participant_id, session_id):
+    """
+    Copy the converted nii image and its accompanying JSON sidecar from the temporary folder to the output BIDS folder.
+    For DWI images, also copy the bval and bvec files.
+
+    :param contrast: Contrast type, e.g., T2w, dwi
+    :param fname: Path to the converted nii image in the temporary folder
     :param output_folder: temporary folder with the converted nii images
     :param participant_id: participant ID, e.g., sub-001
     :param session_id: session ID, e.g., ses-01
-    :param path_t2w: path to the T2w image provided by the user
-    :param path_dwi: path to the DWI image provided by the user
     """
     # First, create anat and dwi subfolders if they do not exist
-    output_folder_anat = os.path.join(output_folder, "anat")
-    os.makedirs(output_folder_anat, exist_ok=True)
-    output_folder_dwi = os.path.join(output_folder, "dwi")
-    os.makedirs(output_folder_dwi, exist_ok=True)
+    if contrast == "dwi":
+        contrast_folder = "dwi"
+    else:
+        contrast_folder = "anat"
+    output_folder = os.path.join(output_folder, contrast_folder)
+    os.makedirs(output_folder, exist_ok=True)
 
     # Second, move the images and JSON sidecars to the respective folders
-    path_t2w_output = os.path.join(output_folder_anat, f"{participant_id}_{session_id}_T2w.nii.gz")
-    path_dwi_output = os.path.join(output_folder_dwi, f"{participant_id}_{session_id}_dwi.nii.gz")
-    shutil.copy(path_t2w, path_t2w_output)
-    shutil.copy(path_t2w.replace('.nii.gz', '.json'), path_t2w_output.replace('.nii.gz', '.json'))
+    fname_output = os.path.join(output_folder, f"{participant_id}_{session_id}_{contrast}.nii.gz")
+    shutil.copy(fname, fname_output)
+    shutil.copy(fname.replace('.nii.gz', '.json'), fname_output.replace('.nii.gz', '.json'))
     # For DWI, we also need to copy the bval and bvec files
-    shutil.copy(path_dwi, path_dwi_output)
-    shutil.copy(path_dwi.replace('.nii.gz', '.json'), path_dwi_output.replace('.nii.gz', '.json'))
-    shutil.copy(path_dwi.replace('.nii.gz', '.bval'), path_dwi_output.replace('.nii.gz', '.bval'))
-    shutil.copy(path_dwi.replace('.nii.gz', '.bvec'), path_dwi_output.replace('.nii.gz', '.bvec'))
-
-    # Lastly, remove the temporary folder
-    shutil.rmtree(os.path.join(output_folder, "temp_dcm2niix"))
+    if contrast == "dwi":
+        shutil.copy(fname.replace('.nii.gz', '.bval'), fname_output.replace('.nii.gz', '.bval'))
+        shutil.copy(fname.replace('.nii.gz', '.bvec'), fname_output.replace('.nii.gz', '.bvec'))
 
 
 def main():
@@ -252,21 +231,40 @@ def main():
         os.makedirs(output_folder, exist_ok=True)
         print(f"\nInfo: Converted NIfTI images will be stored in: {output_folder}")
 
+    # Create a temporary folder to store dcm2niix output before renaming the files
+    temp_folder = os.path.join(output_folder, "temp_dcm2niix")
+    print(f"\nInfo: Creating a temporary folder for NIfTI images: {temp_folder}")
+    os.makedirs(temp_folder, exist_ok=True)
     # Run DICOM to NIfTI conversion using the dcm2niix command
-    run_dcm2niix(dicom_folder, output_folder)
+    run_dcm2niix(dicom_folder, temp_folder)
 
     print(100*"-")
-    print("DICOM to NIfTI is done. Please review the images and provide paths to the T2w and DWI images.")
+    print("DICOM to NIfTI is done. Please review the images and select images for further processing.")
     print(100*"-")
 
-    # Get the paths to the converted T2w and DWI images
-    path_t2w = get_t2_image_path()
-    path_dwi = get_dwi_image_path()
+    nii_info_df = get_nii_info_dataframe(temp_folder)
+    # Display the DataFrame
+    print(f'{nii_info_df}\n')
+
+    # Select images intended for further processing
+    images_to_use_dict = {}
+    for contrast in ["T2w", "dwi"]:
+        images_to_use_dict[contrast] = select_image(contrast, nii_info_df, temp_folder)
 
     # Copy the files to the BIDS folder
-    copy_files_to_bids_folder(output_folder, participant_id, session_id, path_t2w, path_dwi)
+    for contrast, fname in images_to_use_dict.items():
+        print(f"Copying {contrast} image to the BIDS folder.")
+        copy_files_to_bids_folder(contrast, fname, output_folder, participant_id, session_id)
 
-    print("\nAll files have been successfully validated and confirmed.")
+    # Lastly, remove the temporary folder
+    print("\nInfo: Removing the temporary folder {temp_folder}")
+    shutil.rmtree(os.path.join(output_folder, "temp_dcm2niix"))
+
+    print(100*"-")
+    print("All files have been successfully converted and validated. You can find the following images in the "
+          "BIDS folder:")
+    print(f"\t{output_folder}")
+    print(100*"-")
 
 
 if __name__ == "__main__":

--- a/file_loader.py
+++ b/file_loader.py
@@ -11,6 +11,14 @@ Namely, the script:
 Requirements:
     - dcm2niix -- see the Installation section in the README.md file
 
+Example usage:
+    python ~/balgrist-sci/file_loader.py \
+      -dicom-folder ~/data/experiments/balgrist-sci/source_data/dir_20231010 \
+      -bids-folder ~/data/experiments/balgrist-sci/bids \
+      -participant sub-001 \
+      -session ses-01 \
+      -contrasts T2w dwi
+
 Input file structure:
 
     └── source_data

--- a/file_loader.py
+++ b/file_loader.py
@@ -33,6 +33,12 @@ def get_parser():
         required=True
     )
     parser.add_argument(
+        "-bids-folder",
+        help="Path to the BIDS folder where the converted NIfTI images will be stored. "
+             "Example: ~/sci-balgrist-study/bids",
+        required=True
+    )
+    parser.add_argument(
         "-participant",
         help="Participant ID. Example: sub-001",
         required=True
@@ -217,24 +223,33 @@ def main():
     args = get_parser()
 
     dicom_folder = args.dicom_folder
+    bids_folder = args.bids_folder
     participant_id = args.participant
     session_id = args.session
 
     print(100*"-")
     print(f'Dicom folder: {dicom_folder}')
+    print(f'BIDS folder: {bids_folder}')
     print(f'Participant ID: {participant_id}')
     print(f'Session ID: {session_id}')
     print(100*"-")
 
     # Check if the folder with DICOMs exists
     if not os.path.isdir(dicom_folder):
-        print(f"Error: Provided folder with DICOM images does not exist: {args.dicom_folder}")
+        print(f"Error: Provided folder with DICOM images does not exist: {dicom_folder}")
         exit(1)
 
+    # Check whether the BIDS folder already exists, if so, warn the user and exit
+    output_folder = os.path.join(bids_folder, participant_id, session_id)
+    if os.path.isdir(output_folder):
+        print(f"Error: BIDS folder for the provided participant and session already exists: {output_folder}"
+              f"\nPlease remove the existing BIDS folder and rerun the script.")
+        exit(1)
+    else:
+        # Create the output folder if it does not exist
+        os.makedirs(output_folder, exist_ok=True)
+
     # Run DICOM to NIfTI conversion using the dcm2niix command
-    output_folder = os.path.join(os.path.dirname(args.dicom_folder), "bids", participant_id, session_id)
-    # Create the output folder if it does not exist
-    os.makedirs(output_folder, exist_ok=True)
     run_dcm2niix(dicom_folder, output_folder)
 
     print(100*"-")

--- a/file_loader.py
+++ b/file_loader.py
@@ -1,9 +1,9 @@
 """
-This python script provides interactive prompts for users to retry input if files are not found or if the image
-information is not as expected.
+Convert DICOM images to NIfTI format and identify images for the further analysis.
 
 Namely, the script:
-    - allow users to specify paths for T2w and DWI images
+    - run dcm2niix command to convert DICOM images to NIfTI format
+    - prompts the user to select the images for further processing
     - validates file existence
     - checks for .bval and .bvec files for DWI image
     - provides information about the images' dimensions and pixel sizes

--- a/file_loader.py
+++ b/file_loader.py
@@ -111,8 +111,8 @@ def get_image_info(file_path):
     img = nib.load(file_path)
     zooms = img.header.get_zooms()
 
-    dimensions = f"{img.shape[0]} x {img.shape[1]} x {img.shape[2]}"
-    pixel_size = f"{zooms[0]:.2f} mm x {zooms[1]:.2f} mm x {zooms[2]:.2f} mm"
+    dimensions = f"{img.shape[0]}×{img.shape[1]}×{img.shape[2]}"
+    pixel_size = f"{zooms[0]:.2f}×{zooms[1]:.2f}×{zooms[2]:.2f}"
 
     return dimensions, pixel_size
 


### PR DESCRIPTION
This PR:
 - adds [3.1 File organization](https://github.com/sct-pipeline/balgrist-sci/blob/jv/add_data_sctucture_section/README.md#31-file-organization) and [3.2 DICOM to NIfTI conversion](https://github.com/sct-pipeline/balgrist-sci/blob/jv/add_data_sctucture_section/README.md#32-dicom-to-nifti-conversion) sections to the [README](https://github.com/sct-pipeline/balgrist-sci/blob/jv/add_data_sctucture_section/README.md) 
 - adds [file_loader.py](https://github.com/sct-pipeline/balgrist-sci/blob/jv/add_data_sctucture_section/file_loader.py) script for the DICOM to NIfTI conversion and to select the images for further analysis. Example script usage: https://github.com/sct-pipeline/balgrist-sci/pull/3#issuecomment-2305361410

Related: https://github.com/sct-pipeline/balgrist-sci/issues/1