### PR TITLE
Fix folder creation

### DIFF
--- a/file_loader.py
+++ b/file_loader.py
@@ -411,6 +411,7 @@ def main():
                 break
             elif user_input in ['n', 'no']:
                 logging.info("Skipping the DICOM to NIfTI conversion.")
+                print_script_finished()
                 return False
             else:
                 logging.info("Warning: Invalid input. Please enter 'yes' or 'no'.")
@@ -466,9 +467,7 @@ def main():
     source_id = os.path.basename(os.path.normpath(dicom_folder))
     write_participants_tsv(bids_folder, participant_id, session_id, source_id, args.age, args.sex)
 
-    logging.info(100 * "-")
-    logging.info(f'{os.path.abspath(__file__)} finished successfully.')
-    logging.info(100 * "-")
+    print_script_finished()
 
 
 if __name__ == "__main__":

--- a/file_loader.py
+++ b/file_loader.py
@@ -340,6 +340,14 @@ def write_participants_tsv(bids_folder, participant_id, session_id, source_id, a
         ])
         logging.info(f"Info: Added entry for {participant_id}/{session_id} to participants.tsv")
 
+def print_script_finished():
+    """
+    Print a message that the script has finished successfully.
+    """
+    logging.info(100 * "-")
+    logging.info(f'{os.path.abspath(__file__)} finished successfully.')
+    logging.info(100 * "-")
+
 
 def main():
     """

--- a/process_data.sh
+++ b/process_data.sh
@@ -154,7 +154,10 @@ create_results_folder_and_copy_images()
     # Go to folder where data will be copied and processed
     cd "$results_folder"
     # Copy source images
-    cp -r "$bids_folder"/"$participant_id"/"$session_id" .
+    mkdir -p "$participant_id"
+    cp -r "$bids_folder/$participant_id/$session_id" "$participant_id/"
+    # Note: We need to create "$participant_id" first, to preserve the directory structure (e.g., sub-001/ses-01) when
+    # copying the files. Otherwise, only ses-01 folder would be copied to the results folder.
 }
 
 # Inspiration: https://github.com/spinalcordtoolbox/sct_tutorial_data/blob/master/multi_subject/process_data.sh#L66-L89


### PR DESCRIPTION
This PR fixes the following error:

```
...
----------------------------------------------------------------------------------------------------
/Users/valosek/code/balgrist-sci/file_loader.py finished successfully.
----------------------------------------------------------------------------------------------------
process_data.sh: line 219: cd: sub-001/ses-01: No such file or directory
```

This error was caused by a minor bug in `process_data.sh` in the following command:

```bash
cd "$results_folder"
cp -r "$bids_folder/$participant_id/$session_id" "$participant_id/"
```

By running `cp` in this way, only `$session_id` was copied to `$results_folder`. But not `$participant_id`. 
So this PR fixes this issue by first creating `$participant_id` using `mkdir`:

```bash
# Go to folder where data will be copied and processed
cd "$results_folder"
# Copy source images
mkdir -p "$participant_id"
cp -r "$bids_folder/$participant_id/$session_id" "$participant_id/"
```  

---

I'll retest and review the PR by myself later today and then merge it to be ready for tomorrow's meeting with collaborators.  

