### PR TITLE
Expand pipeline to t2w ax and t2w sag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Steps:
 
 ### 1.1 Dependencies
 
-* [Spinal Cord Toolbox v6.5](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/6.5): toolbox for processing spinal cord MRI data
+* [Spinal Cord Toolbox v7.0](https://github.com/spinalcordtoolbox/spinalcordtoolbox/releases/tag/7.0): toolbox for processing spinal cord MRI data
 * [dcm2niix >= v1.0.20220505](https://github.com/rordenlab/dcm2niix?tab=readme-ov-file#install): tool for converting DICOM images into the NIfTI format
 * [FSLeyes](https://owncloud.cesnet.cz/index.php/s/z5h02r0cq0B7ESf): tool for visualizing NIfTI images
 
@@ -48,14 +48,14 @@ Press <kbd>command</kbd> + <kbd>space</kbd> and type `Terminal` and press <kbd>r
 ```bash
 # Go to your home directory
 cd ~
-# Download SCT v6.5
-curl -L -o 6.5.zip https://github.com/spinalcordtoolbox/spinalcordtoolbox/archive/refs/tags/6.5.zip
-# Unzip the downloaded file --> the unzipped directory will be named spinalcordtoolbox-6.5
-unzip 6.5.zip
-rm 6.5.zip
+# Download SCT v7.0
+curl -L -o 7.0.zip https://github.com/spinalcordtoolbox/spinalcordtoolbox/archive/refs/tags/7.0.zip
+# Unzip the downloaded file --> the unzipped directory will be named spinalcordtoolbox-7.0
+unzip 7.0.zip
+rm 7.0.zip
 # Go to the SCT directory
-cd spinalcordtoolbox-6.5
-# Install SCT v6.5
+cd spinalcordtoolbox-7.0
+# Install SCT v7.0
 ./install_sct -iyc
 #  '-i'   Install in-place (i.e., in the current directory)
 #  '-y'   Install without interruption with 'yes' as default answer

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ MANDATORY ARGUMENTS
   -r <results folder>         Path to the folder where the results will be stored. Example: ~/sci-balgrist-study/data_processed
   -p <participant id>         Participant ID. Example: sub-001
   -s <session id>             Session ID. Example: ses-01
-  -c <contrasts>              MRI contrasts to use (space-separated if multiple). Examples: 'T2w' or 'T2w dwi'
+  -c <contrasts>              MRI contrasts to use (space-separated if multiple). Examples: 'acq-ax_T2w' or 'acq-sag_T2w'
 
 OPTIONAL ARGUMENTS
   -a <age>                  Age of the subject at the time of the MRI scan. The provided value will be stored to participants.tsv file. Example: 25. Default: n/a
@@ -293,7 +293,7 @@ bash process_data.sh \
   -r ~/data/experiments/balgrist-sci/data_processed \
   -p sub-001 \
   -s ses-01 \
-  -c T2w dwi \
+  -c acq-ax_T2w acq-sag_T2w \
   -a 30 \
   -x M
 ```

--- a/README.md
+++ b/README.md
@@ -208,14 +208,14 @@ The rest of the directories and files will be created during the processing; see
 ├── bids                    --> folder with BIDS-compliant data
 │    ├── sub-001            --> folder containing NIfTI files for first subject
 │    │   ├── ses-01         --> first session
-│    │   │  ├── anat        --> folder with anatomical data
-│    │   │  │  ├── sub-001_ses-01_T1w.nii.gz
-│    │   │  │  ├── sub-001_ses-01_T2w.nii.gz
-│    │   │  │  ├── ...
 │    │   │  └── dwi         --> folder with diffusion data
 │    │   │     ├── sub-001_ses-01_dwi.nii.gz
 │    │   │     ├── sub-001_ses-01_dwi.bval
 │    │   │     ├── sub-001_ses-01_dwi.bvec
+│    │   │  └── anat        --> folder with anatomical data
+│    │   │     ├── sub-001_ses-01_acq-sag_T2w.nii.gz
+│    │   │     ├── sub-001_ses-01_acq-ax_T2w.nii.gz
+│    │   │     ├── ...
 │    │   └── ses-02         --> second session
 │    │      ├── ...
 │    ├── sub-002            --> folder containing NIfTI files for second subject
@@ -225,10 +225,6 @@ The rest of the directories and files will be created during the processing; see
 │        └── labels
 │            ├── sub-001    --> first subject
 │            │   ├── ses-01 --> first session
-│            │   │  ├── anat
-│            │   │  │  ├── sub-001_ses-01_T2w_label-SC_seg.nii.gz              --> spinal cord (SC) binary segmentation
-│            │   │  │  ├── sub-001_ses-01_T2w_label-compression_label.nii.gz   --> binary compression labeling
-│            │   │  │  ├── ...
 │            │   │  └── dwi
 │            │   │     ├── sub-001_ses-01_dwi_label-SC_seg.nii.gz
 │            │   │     ├── ...

--- a/README.md
+++ b/README.md
@@ -208,10 +208,6 @@ The rest of the directories and files will be created during the processing; see
 ├── bids                    --> folder with BIDS-compliant data
 │    ├── sub-001            --> folder containing NIfTI files for first subject
 │    │   ├── ses-01         --> first session
-│    │   │  └── dwi         --> folder with diffusion data
-│    │   │     ├── sub-001_ses-01_dwi.nii.gz
-│    │   │     ├── sub-001_ses-01_dwi.bval
-│    │   │     ├── sub-001_ses-01_dwi.bvec
 │    │   │  └── anat        --> folder with anatomical data
 │    │   │     ├── sub-001_ses-01_acq-sag_T2w.nii.gz
 │    │   │     ├── sub-001_ses-01_acq-ax_T2w.nii.gz
@@ -225,8 +221,9 @@ The rest of the directories and files will be created during the processing; see
 │        └── labels
 │            ├── sub-001    --> first subject
 │            │   ├── ses-01 --> first session
-│            │   │  └── dwi
-│            │   │     ├── sub-001_ses-01_dwi_label-SC_seg.nii.gz
+│            │   │  └── anat
+│            │   │     ├── sub-001_ses-01_acq-sag_T2w_label-SC_seg.nii.gz      --> spinal cord (SC) binary segmentation
+│            │   │     ├── sub-001_ses-01_acq-sag_T2w_label-disc.nii.gz        --> discrete discs labeling
 │            │   │     ├── ...
 │            │   └── ses-02 --> second session
 │            │      ├── ...

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ MANDATORY ARGUMENTS
   -r <results folder>         Path to the folder where the results will be stored. Example: ~/sci-balgrist-study/data_processed
   -p <participant id>         Participant ID. Example: sub-001
   -s <session id>             Session ID. Example: ses-01
-  -c <contrasts>              MRI contrasts to use (space-separated if multiple). Examples: 'acq-ax_T2w' or 'acq-sag_T2w'
+  -c <contrasts>              MRI contrasts to use (space-separated if multiple). Examples: 'acq-sag_T2w' and/or 'acq-ax_T2w'
 
 OPTIONAL ARGUMENTS
   -a <age>                  Age of the subject at the time of the MRI scan. The provided value will be stored to participants.tsv file. Example: 25. Default: n/a
@@ -293,7 +293,7 @@ bash process_data.sh \
   -r ~/data/experiments/balgrist-sci/data_processed \
   -p sub-001 \
   -s ses-01 \
-  -c acq-ax_T2w acq-sag_T2w \
+  -c acq-sag_T2w acq-ax_T2w \
   -a 30 \
   -x M
 ```

--- a/file_loader.py
+++ b/file_loader.py
@@ -320,7 +320,7 @@ def get_nii_info_dataframe(temp_folder):
     df = pd.DataFrame({
         'File Name': file_names,
         'Contrast': contrast_list,
-        'Orienation': orientation_list,
+        'Orientation': orientation_list,
         'Dimensions': dimensions_list,
         'Pixel Size [mm]': pixel_sizes
     })

--- a/file_loader.py
+++ b/file_loader.py
@@ -160,7 +160,7 @@ def run_dcm2niix(dicom_folder, temp_folder):
     cmd = [
         "dcm2niix",
         "-z", "y",      # Compress output
-        "-f", "%d_%p_%s",  # Custom filename format: %d - series description, %p - protocol name, %s - series number
+        "-f", "%d_%s",  # Custom filename format: %d - series description, %s - series number
         "-i", "y",      # Ignore derived, localizer and 2D images
         "-o", temp_folder,
         dicom_folder

--- a/process_data.sh
+++ b/process_data.sh
@@ -198,7 +198,7 @@ segment_if_does_not_exist() {
     # TODO: add an entry who QCed and corrected the segmentation to the JSON sidecar
     cp "${FILESEG}".json "${FILESEGMANUAL}".json
 
-    echo -e "Spinal cord segmentation saved as:\n"${FILESEGMANUAL}".nii.gz"
+    echo_with_linebreaks "Spinal cord segmentation saved as:\n\t"${FILESEGMANUAL}".nii.gz\n"
 
   fi
 }

--- a/process_data.sh
+++ b/process_data.sh
@@ -297,7 +297,6 @@ bring_sag_disc_lables_to_ax()
   sct_label_utils -i ${file_t2_ax_seg}.nii.gz -disc ${file_t2_ax_labels}.nii.gz -o ${file_t2_ax_seg}_labeled.nii.gz
   # Generate QC report to assess labeled segmentation
   sct_qc -i ${file_t2_ax}.nii.gz -s ${file_t2_ax_seg}_labeled.nii.gz -p sct_label_vertebrae -qc ${PATH_QC} -qc-subject ${SUBJECT}
-
 }
 
 process_t2w_sag()

--- a/process_data.sh
+++ b/process_data.sh
@@ -130,7 +130,12 @@ echo_with_linebreaks()
 
 echo_fsleyes_instructions_seg()
 {
-    echo_with_linebreaks "Opening FSLeyes, it might take a few seconds...\nCheck the quality of the segmentation, correct the segmentation if necessary ('Tools' --> 'Edit mode'),\nand save it by overwriting the existing file ('Overlay' --> 'Save' --> 'Overwrite').\nThen close FSLeyes to continue."
+    echo_with_linebreaks "
+    Opening FSLeyes, it might take a few seconds...
+    Check the quality of the segmentation, correct the segmentation if necessary ('Tools' --> 'Edit mode'),
+    and save it by overwriting the existing file ('Overlay' --> 'Save' --> 'Overwrite').
+    Then close FSLeyes to continue.
+    "
 }
 
 echo_fsleyes_instructions_compression()

--- a/process_data.sh
+++ b/process_data.sh
@@ -194,6 +194,7 @@ segment_if_does_not_exist() {
     echo_fsleyes_instructions
     fsleyes "$file_t2".nii.gz "${FILESEG}.nii.gz" -cm red -a 70.0
     # Copy the visually verified segmentation (and potentially manually corrected SC seg) to the derivatives folder
+    # (to be reused in the future analysis)
     cp "${FILESEG}".nii.gz "${FILESEGMANUAL}".nii.gz
     # TODO: add an entry who QCed and corrected the segmentation to the JSON sidecar
     cp "${FILESEG}".json "${FILESEGMANUAL}".json
@@ -209,11 +210,12 @@ label_if_does_not_exist(){
   #  This function checks if a manual disc label file already exists, then:
   #     - If it does, copy it locally.
   #     - If it doesn't, perform automatic labeling.
+  #   Then, the function generates a labeled segmentation using the disc labels.
   #   This allows you to add manual labels on a subject-by-subject basis without disrupting the pipeline.
   ###
   local file="$1"
   local file_seg="$2"
-  local contrast="$3"   # used for sct_label_vertebrae to create labeled segmentation from disc labels created by TotalSpineSeg
+  local contrast="$3"    # acq-sag_T2w or acq-ax_T2w
   # Copy manual disc labels from derivatives/labels if they exist
   FILELABEL="${file}_label-disc"
   FILELABELMANUAL="${bids_folder}/derivatives/labels/${SUBJECT}/anat/${FILELABEL}"

--- a/process_data.sh
+++ b/process_data.sh
@@ -292,6 +292,7 @@ bring_sag_disc_lables_to_ax()
   #     - Label T2w axial spinal cord segmentation using the disc labels.
   # Context: https://github.com/sct-pipeline/dcm-metric-normalization/issues/9
   # Inspired by: https://github.com/sct-pipeline/dcm-metric-normalization/blob/r20250320/scripts/process_data_dcm-zurich.sh#L155-L176
+  ###
   local file_t2_ax="$1"
   local file_t2_ax_seg="$2"
   local file_t2_sag="${file_t2_ax/-ax/-sag}"    # TODO: this is very fragile, we should use a more robust way

--- a/process_data.sh
+++ b/process_data.sh
@@ -125,7 +125,7 @@ echo_with_linebreaks()
 
 echo_fsleyes_instructions()
 {
-    echo_with_linebreaks "Opening FSLeyes (close FSLeyes to continue)...\nCheck the quality of the segmentation, correct the segmentation if necessary ('Tools' --> 'Edit mode'),\nand save it by overwriting the existing file ('Overlay' --> 'Save' --> 'Overwrite').\nThen close FSLeyes to continue."
+    echo_with_linebreaks "Opening FSLeyes, it might take a few seconds...\nCheck the quality of the segmentation, correct the segmentation if necessary ('Tools' --> 'Edit mode'),\nand save it by overwriting the existing file ('Overlay' --> 'Save' --> 'Overwrite').\nThen close FSLeyes to continue."
 }
 
 # Convert DICOM files to NIfTI format using the file_loader.py script, which calls the dcm2niix function

--- a/process_data.sh
+++ b/process_data.sh
@@ -291,6 +291,7 @@ main_analysis()
     cd "${SUBJECT}"
 
     # Loop across contrasts (specified by the '-c' arg)
+    # TODO: the order the contrasts are processed is determined by the order they are specified in the command line
     for contrast in "${contrasts[@]}"; do
         case $contrast in
             acq-sag_T2w)

--- a/process_data.sh
+++ b/process_data.sh
@@ -128,7 +128,7 @@ echo_with_linebreaks()
     echo "${line}"
 }
 
-echo_fsleyes_instructions()
+echo_fsleyes_instructions_seg()
 {
     echo_with_linebreaks "Opening FSLeyes, it might take a few seconds...\nCheck the quality of the segmentation, correct the segmentation if necessary ('Tools' --> 'Edit mode'),\nand save it by overwriting the existing file ('Overlay' --> 'Save' --> 'Overwrite').\nThen close FSLeyes to continue."
 }
@@ -191,7 +191,7 @@ segment_if_does_not_exist() {
     sct_deepseg spinalcord -i "${file}".nii.gz -o "${FILESEG}".nii.gz -qc "${PATH_QC}" -qc-subject "${SUBJECT}"
 
     # Open FSLeyes to visualize the segmentation
-    echo_fsleyes_instructions
+    echo_fsleyes_instructions_seg
     fsleyes "$file_t2".nii.gz "${FILESEG}.nii.gz" -cm red -a 70.0
     # Copy the visually verified segmentation (and potentially manually corrected SC seg) to the derivatives folder
     # (to be reused in the future analysis)

--- a/process_data.sh
+++ b/process_data.sh
@@ -204,7 +204,7 @@ segment_if_does_not_exist() {
   fi
 }
 
-label_if_does_not_exist(){
+label_discs_if_does_not_exist(){
   ###
   #  This function checks if a manual disc label file already exists, then:
   #     - If it does, copy it locally.
@@ -313,7 +313,7 @@ process_t2w_sag()
     # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal
     segment_if_does_not_exist "$file_t2" t2
     file_t2_seg="${FILESEG}"
-    label_if_does_not_exist "$file_t2" "$file_t2_seg" acq-sag
+    label_discs_if_does_not_exist "$file_t2" "$file_t2_seg" acq-sag
 
     # Go back to the subject root folder
     cd ..

--- a/process_data.sh
+++ b/process_data.sh
@@ -221,7 +221,7 @@ label_discs_if_does_not_exist(){
   echo "Looking for manual disc labels: ${FILELABELMANUAL}.nii.gz"
   if [[ -e ${FILELABELMANUAL}.nii.gz ]]; then
     echo "Found! Using manual disc labels."
-    cp $FILELABELMANUAL.nii.gz ${FILELABEL}.nii.gz
+    cp ${FILELABELMANUAL}.nii.gz ${FILELABEL}.nii.gz
     # cp "${FILELABELMANUAL}".json "${FILELABEL}".json  # TODO: uncomment once we have a JSON sidecar for disc labels
     # Generate labeled segmentation from manual disc labels
     sct_label_vertebrae -i ${file}.nii.gz -s ${file_seg}.nii.gz -discfile ${FILELABEL}.nii.gz -c t2 -qc ${PATH_QC} -qc-subject ${SUBJECT}

--- a/process_data.sh
+++ b/process_data.sh
@@ -384,6 +384,17 @@ process_t2w_ax()
 
     bring_sag_disc_lables_to_ax "${file_t2_ax}" "${file_t2_ax_seg}"
 
+    label_compression_if_does_not_exist "${file_t2_ax}"
+    file_t2_ax_compression="${FILECOMPRESSION}"
+
+    metrics="diameter_AP area diameter_RL eccentricity solidity"
+    for metric in ${metrics}; do
+        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -l ${file_t2_ax_compression}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -mode compression -metric ${metric} -o ${PATH_RESULTS}/mscc.csv
+        # TODO: use also '-sex' and '-age' args when they are provided
+    done
+
+    echo_with_linebreaks "Compression metrics saved as:\n\t"${PATH_RESULTS}"/mscc.csv"
+
     # Go back to the subject root folder
     cd ..
 }
@@ -395,6 +406,11 @@ main_analysis()
 
     # Define path to the folder where QC will be stored
     PATH_QC="${results_folder}"/qc
+    PATH_RESULTS="${results_folder}"/results
+    # Create PATH_RESULTS if it does not exist
+    if [ ! -d "${PATH_RESULTS}" ]; then
+        mkdir -p "${PATH_RESULTS}"
+    fi
     SUBJECT="${participant_id}/${session_id}"
     # TODO: add a path for log files
 

--- a/process_data.sh
+++ b/process_data.sh
@@ -286,6 +286,7 @@ main_analysis()
     # Define path to the folder where QC will be stored
     PATH_QC="${results_folder}"/qc
     SUBJECT="${participant_id}/${session_id}"
+    # TODO: add a path for log files
 
     # Go to subject folder in the results folder
     cd "${SUBJECT}"

--- a/process_data.sh
+++ b/process_data.sh
@@ -56,7 +56,7 @@ MANDATORY ARGUMENTS
   -r <results folder>         Path to the folder where the results will be stored. Example: ~/sci-balgrist-study/data_processed
   -p <participant id>         Participant ID. Example: sub-001
   -s <session id>             Session ID. Example: ses-01
-  -c <contrasts>              MRI contrasts to use (space-separated if multiple). Examples: 'acq-ax_T2w' or 'acq-sag_T2w'
+  -c <contrasts>              MRI contrasts to use (space-separated if multiple). Examples: 'acq-sag_T2w' and/or 'acq-ax_T2w'
 
 OPTIONAL ARGUMENTS
   -a <age>                  Age of the subject at the time of the MRI scan. The provided value will be stored to participants.tsv file. Example: 25. Default: n/a

--- a/process_data.sh
+++ b/process_data.sh
@@ -293,13 +293,13 @@ main_analysis()
     # Loop across contrasts (specified by the '-c' arg)
     for contrast in "${contrasts[@]}"; do
         case $contrast in
-            acq-ax_T2w)
-                echo_with_linebreaks "Processing T2w axial image..."
-                process_t2w_ax $contrast
-                ;;
             acq-sag_T2w)
                 echo_with_linebreaks "Processing T2w sagittal image..."
                 process_t2w_sag $contrast
+                ;;
+            acq-ax_T2w)
+                echo_with_linebreaks "Processing T2w axial image..."
+                process_t2w_ax $contrast
                 ;;
             *)
                 echo "Analysis for $contrast is not implemented yet :-(. Skipping..."

--- a/process_data.sh
+++ b/process_data.sh
@@ -209,6 +209,24 @@ process_t2w_ax()
     echo -e "Spinal cord segmentation saved as:\n${bids_folder}/derivatives/labels/${SUBJECT}/anat/${file_t2_seg}.nii.gz"
 }
 
+process_t2w_sag()
+{
+    local suffix=$1
+    # Go to anat folder where all structural data are located
+    cd anat
+
+    # Construct the file name based on the subject ID, e.g., sub-001_ses-01_acq-sag_T2w
+    file_t2="${participant_id}_${session_id}_${suffix}"
+
+    # Segment spinal cord (only if it does not exist)
+    # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal
+    segment_if_does_not_exist "$file_t2" t2
+    file_t2_seg="${FILESEG}"
+
+    # Go back to the subject root folder
+    cd ..
+}
+
 main_analysis()
 {
     # Create the results folder and copy the images to it
@@ -228,9 +246,10 @@ main_analysis()
                 echo_with_linebreaks "Processing T2w axial image..."
                 process_t2w_ax $contrast
                 ;;
-#            dwi)
-#                echo "Processing DWI images..."
-#                ;;
+            acq-sag_T2w)
+                echo_with_linebreaks "Processing T2w sagittal image..."
+                process_t2w_sag $contrast
+                ;;
             *)
                 echo "Analysis for $contrast is not implemented yet :-(. Skipping..."
 #                echo "Unknown contrast: $contrast"

--- a/process_data.sh
+++ b/process_data.sh
@@ -18,7 +18,7 @@
 #       -r ~/data/experiments/balgrist-sci/data_processed \
 #       -p sub-001 \
 #       -s ses-01 \
-#       -c T2w dwi \
+#       -c acq-ax_T2w acq-sag_T2w \
 #       -a 30 \
 #       -x M
 #
@@ -51,7 +51,7 @@ MANDATORY ARGUMENTS
   -r <results folder>         Path to the folder where the results will be stored. Example: ~/sci-balgrist-study/data_processed
   -p <participant id>         Participant ID. Example: sub-001
   -s <session id>             Session ID. Example: ses-01
-  -c <contrasts>              MRI contrasts to use (space-separated if multiple). Examples: 'T2w' or 'T2w dwi'
+  -c <contrasts>              MRI contrasts to use (space-separated if multiple). Examples: 'acq-ax_T2w' or 'acq-sag_T2w'
 
 OPTIONAL ARGUMENTS
   -a <age>                  Age of the subject at the time of the MRI scan. The provided value will be stored to participants.tsv file. Example: 25. Default: n/a
@@ -186,13 +186,13 @@ segment_if_does_not_exist() {
   fi
 }
 
-process_t2w()
+process_t2w_ax()
 {
     local suffix=$1
     # Go to anat folder where all structural data are located
     cd anat
 
-    # Construct the file name based on the subject ID, e.g., sub-001_ses-01_T2w
+    # Construct the file name based on the subject ID, e.g., sub-001_ses-01_acq-ax_T2w
     file_t2="${participant_id}_${session_id}_${suffix}"
 
     # Segment spinal cord (only if it does not exist)
@@ -224,9 +224,9 @@ main_analysis()
     # Loop across contrasts (specified by the '-c' arg)
     for contrast in "${contrasts[@]}"; do
         case $contrast in
-            T2w)
-                echo_with_linebreaks "Processing T2w image..."
-                process_t2w $contrast
+            acq-ax_T2w)
+                echo_with_linebreaks "Processing T2w axial image..."
+                process_t2w_ax $contrast
                 ;;
 #            dwi)
 #                echo "Processing DWI images..."

--- a/process_data.sh
+++ b/process_data.sh
@@ -11,16 +11,21 @@
 #   - dcm2niix
 #   - FSLeyes
 #
-# Example usage:
-#     bash process_data.sh \
-#       -d ~/data/experiments/balgrist-sci/source_data/dir_20231010 \
-#       -b ~/data/experiments/balgrist-sci/bids \
-#       -r ~/data/experiments/balgrist-sci/data_processed \
-#       -p sub-001 \
-#       -s ses-01 \
-#       -c acq-ax_T2w acq-sag_T2w \
-#       -a 30 \
-#       -x M
+# Usage:
+#   1. Activate the SCT conda environment:
+#       source ${SCT_DIR}/python/etc/profile.d/conda.sh
+#       conda activate venv_sct
+#
+#   2. Example usage:
+#       bash process_data.sh \
+#        -d ~/data/experiments/balgrist-sci/source_data/dir_20231010 \
+#        -b ~/data/experiments/balgrist-sci/bids \
+#        -r ~/data/experiments/balgrist-sci/data_processed \
+#        -p sub-001 \
+#        -s ses-01 \
+#        -c acq-ax_T2w acq-sag_T2w \
+#        -a 30 \
+#        -x M
 #
 # Authors: Jan Valosek, Sandrine Bedard
 # AI assistance: Claude 3.5 Sonnet, ChatGPT-4o, and GitHub Copilot

--- a/process_data.sh
+++ b/process_data.sh
@@ -300,6 +300,25 @@ bring_sag_disc_lables_to_ax()
 
 }
 
+process_t2w_sag()
+{
+    local suffix=$1
+    # Go to anat folder where all structural data are located
+    cd anat
+
+    # Construct the file name based on the subject ID, e.g., sub-001_ses-01_acq-sag_T2w
+    file_t2="${participant_id}_${session_id}_${suffix}"
+
+    # Segment spinal cord (only if it does not exist)
+    # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal
+    segment_if_does_not_exist "$file_t2" t2
+    file_t2_seg="${FILESEG}"
+    label_if_does_not_exist "$file_t2" "$file_t2_seg" acq-sag
+
+    # Go back to the subject root folder
+    cd ..
+}
+
 process_t2w_ax()
 {
     local suffix=$1
@@ -315,25 +334,6 @@ process_t2w_ax()
     file_t2_seg="${FILESEG}"
 
     bring_sag_disc_lables_to_ax "${file_t2}" "${file_t2_seg}"
-
-    # Go back to the subject root folder
-    cd ..
-}
-
-process_t2w_sag()
-{
-    local suffix=$1
-    # Go to anat folder where all structural data are located
-    cd anat
-
-    # Construct the file name based on the subject ID, e.g., sub-001_ses-01_acq-sag_T2w
-    file_t2="${participant_id}_${session_id}_${suffix}"
-
-    # Segment spinal cord (only if it does not exist)
-    # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal
-    segment_if_does_not_exist "$file_t2" t2
-    file_t2_seg="${FILESEG}"
-    label_if_does_not_exist "$file_t2" "$file_t2_seg" acq-sag
 
     # Go back to the subject root folder
     cd ..

--- a/process_data.sh
+++ b/process_data.sh
@@ -333,7 +333,7 @@ process_t2w_sag()
     # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal
     segment_if_does_not_exist "$file_t2" t2
     file_t2_seg="${FILESEG}"
-    label_if_does_not_exist "$file_t2" "$file_t2_seg" t2
+    label_if_does_not_exist "$file_t2" "$file_t2_seg" acq-sag
 
     # Go back to the subject root folder
     cd ..

--- a/process_data.sh
+++ b/process_data.sh
@@ -278,8 +278,8 @@ bring_sag_disc_lables_to_ax()
   # Inspired by: https://github.com/sct-pipeline/dcm-metric-normalization/blob/r20250320/scripts/process_data_dcm-zurich.sh#L155-L176
   local file_t2_ax="$1"
   local file_t2_ax_seg="$2"
-  local file_t2_sag="${file_t2_ax/-ax/-sag}"    # TODO: this is very fragile, we should use a more robust way to
-  local file_t2_sag_seg="${file_t2_ax_seg/-ax/-sag}"    # TODO: this is very fragile, we should use a more robust way to
+  local file_t2_sag="${file_t2_ax/-ax/-sag}"    # TODO: this is very fragile, we should use a more robust way
+  local file_t2_sag_seg="${file_t2_ax_seg/-ax/-sag}"    # TODO: this is very fragile, we should use a more robust way
 
   # Note: the '-dseg' is used only for the QC report
   sct_register_multimodal -i ${file_t2_sag}.nii.gz -d ${file_t2_ax}.nii.gz -identity 1 -x nn -qc ${PATH_QC} -qc-subject ${SUBJECT} -dseg ${file_t2_ax_seg}.nii.gz

--- a/process_data.sh
+++ b/process_data.sh
@@ -302,12 +302,12 @@ bring_sag_disc_lables_to_ax()
 
 process_t2w_sag()
 {
-    local suffix=$1
+    local contrast=$1
     # Go to anat folder where all structural data are located
     cd anat
 
     # Construct the file name based on the subject ID, e.g., sub-001_ses-01_acq-sag_T2w
-    file_t2="${participant_id}_${session_id}_${suffix}"
+    file_t2="${participant_id}_${session_id}_${contrast}"
 
     # Segment spinal cord (only if it does not exist)
     # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal
@@ -321,12 +321,12 @@ process_t2w_sag()
 
 process_t2w_ax()
 {
-    local suffix=$1
+    local contrast=$1
     # Go to anat folder where all structural data are located
     cd anat
 
     # Construct the file name based on the subject ID, e.g., sub-001_ses-01_acq-ax_T2w
-    file_t2="${participant_id}_${session_id}_${suffix}"
+    file_t2="${participant_id}_${session_id}_${contrast}"
 
     # Segment spinal cord (only if it does not exist)
     # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal

--- a/process_data.sh
+++ b/process_data.sh
@@ -306,13 +306,13 @@ process_t2w_sag()
     cd anat
 
     # Construct the file name based on the subject ID, e.g., sub-001_ses-01_acq-sag_T2w
-    file_t2="${participant_id}_${session_id}_${contrast}"
+    file_t2_sag="${participant_id}_${session_id}_${contrast}"
 
     # Segment spinal cord (only if it does not exist)
     # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal
-    segment_if_does_not_exist "$file_t2" t2
-    file_t2_seg="${FILESEG}"
-    label_discs_if_does_not_exist "$file_t2" "$file_t2_seg" acq-sag
+    segment_if_does_not_exist "$file_t2_sag" t2
+    file_t2_sag_seg="${FILESEG}"
+    label_discs_if_does_not_exist "$file_t2_sag" "$file_t2_sag_seg" acq-sag
 
     # Go back to the subject root folder
     cd ..
@@ -325,14 +325,14 @@ process_t2w_ax()
     cd anat
 
     # Construct the file name based on the subject ID, e.g., sub-001_ses-01_acq-ax_T2w
-    file_t2="${participant_id}_${session_id}_${contrast}"
+    file_t2_ax="${participant_id}_${session_id}_${contrast}"
 
     # Segment spinal cord (only if it does not exist)
     # TODO: redirect sct_deepseg_sc output to LOG file to do not clutter the users terminal
-    segment_if_does_not_exist "$file_t2" t2
-    file_t2_seg="${FILESEG}"
+    segment_if_does_not_exist "$file_t2_ax" t2
+    file_t2_ax_seg="${FILESEG}"
 
-    bring_sag_disc_lables_to_ax "${file_t2}" "${file_t2_seg}"
+    bring_sag_disc_lables_to_ax "${file_t2_ax}" "${file_t2_ax_seg}"
 
     # Go back to the subject root folder
     cd ..

--- a/process_data.sh
+++ b/process_data.sh
@@ -188,7 +188,7 @@ segment_if_does_not_exist() {
   else
     echo "Not found. Proceeding with automatic segmentation."
     # Segment spinal cord
-    sct_deepseg -i "${file}".nii.gz -task seg_sc_contrast_agnostic -o "${FILESEG}".nii.gz -qc "${PATH_QC}" -qc-subject "${SUBJECT}"
+    sct_deepseg spinalcord -i "${file}".nii.gz -o "${FILESEG}".nii.gz -qc "${PATH_QC}" -qc-subject "${SUBJECT}"
 
     # Open FSLeyes to visualize the segmentation
     echo_fsleyes_instructions

--- a/process_data.sh
+++ b/process_data.sh
@@ -172,12 +172,13 @@ segment_if_does_not_exist() {
   local contrast="${2}"
   # Update global variable with segmentation file name
   FILESEG="${file}"_label-SC_seg
-  FILESEGMANUAL="${bids_folder}"/derivatives/labels/"${SUBJECT}"/anat/"${FILESEG}".nii.gz
+  FILESEGMANUAL="${bids_folder}"/derivatives/labels/"${SUBJECT}"/anat/"${FILESEG}"
   echo
-  echo "Looking for manual segmentation: ${FILESEGMANUAL}"
-  if [[ -e "${FILESEGMANUAL}" ]]; then
+  echo "Looking for manual segmentation: ${FILESEGMANUAL}.nii.gz"
+  if [[ -e "${FILESEGMANUAL}".nii.gz ]]; then
     echo "Found! Using manual segmentation."
-    cp "${FILESEGMANUAL}" "${FILESEG}".nii.gz
+    cp "${FILESEGMANUAL}".nii.gz "${FILESEG}".nii.gz
+    cp "${FILESEGMANUAL}".json "${FILESEG}".json
     sct_qc -i "${file}".nii.gz -s "${FILESEG}".nii.gz -p sct_deepseg_sc -qc "${PATH_QC}" -qc-subject "${SUBJECT}"
   else
     echo "Not found. Proceeding with automatic segmentation."

--- a/process_data.sh
+++ b/process_data.sh
@@ -183,6 +183,17 @@ segment_if_does_not_exist() {
     echo "Not found. Proceeding with automatic segmentation."
     # Segment spinal cord
     sct_deepseg -i "${file}".nii.gz -task seg_sc_contrast_agnostic -o "${FILESEG}".nii.gz -qc "${PATH_QC}" -qc-subject "${SUBJECT}"
+
+    # Open FSLeyes to visualize the segmentation
+    echo_fsleyes_instructions
+    fsleyes "$file_t2".nii.gz "${FILESEG}.nii.gz" -cm red -a 70.0
+    # Copy the visually verified segmentation (and potentially manually corrected SC seg) to the derivatives folder
+    cp "${FILESEG}".nii.gz "${FILESEGMANUAL}".nii.gz
+    # TODO: add an entry who QCed and corrected the segmentation to the JSON sidecar
+    cp "${FILESEG}".json "${FILESEGMANUAL}".json
+
+    echo -e "Spinal cord segmentation saved as:\n"${FILESEGMANUAL}".nii.gz"
+
   fi
 }
 
@@ -200,13 +211,8 @@ process_t2w_ax()
     segment_if_does_not_exist "$file_t2" t2
     file_t2_seg="${FILESEG}"
 
-    # Open FSLeyes to visualize the segmentation
-    echo_fsleyes_instructions
-    fsleyes "$file_t2".nii.gz "${file_t2_seg}.nii.gz" -cm red -a 70.0
-    # Copy the visually verified segmentation (and potentially manually corrected SC seg) to the derivatives folder
-    cp "${file_t2_seg}".nii.gz "${bids_folder}"/derivatives/labels/"${SUBJECT}"/anat/
-    # TODO: continue with the analysis
-    echo -e "Spinal cord segmentation saved as:\n${bids_folder}/derivatives/labels/${SUBJECT}/anat/${file_t2_seg}.nii.gz"
+    # Go back to the subject root folder
+    cd ..
 }
 
 process_t2w_sag()


### PR DESCRIPTION
### Documentation updates:
* Updated `README.md` to reflect the upgrade from Spinal Cord Toolbox v6.5 to v7.0 and revised examples to use `acq-sag_T2w` and `acq-ax_T2w` contrasts instead of generic `T2w` or `dwi`.
* Updated directory structure examples in `README.md` to reflect changes in file naming conventions and added new labels for sagittal and axial contrasts.

### Enhancements to `file_loader.py`:
* Added helper functions `_fetch_contrast` and `_fetch_orientation` to extract MRI contrast and orientation from filenames using regex. These are integrated into the `get_nii_info_dataframe` function to include `Contrast` and `Orientation` columns in the output DataFrame.
* Simplified the custom filename format in `run_dcm2niix` by removing the protocol name (`%p`) to ensure more consistent output.

### Improvements to the Processing Pipeline in `process_data.sh`:
* Introduced separate functions for processing sagittal (`process_t2w_sag`) and axial (`process_t2w_ax`) T2w images, enabling more modular handling of different contrasts.
* Added new functions for handling manual and automatic labeling of spinal cord segmentations and intervertebral discs, including quality control (QC) steps and user-guided corrections.
* Enhanced the pipeline to bring sagittal disc labels into axial space for better alignment and labeling consistency.

### TODO:

- [x] update the pipeline to SCT v7.0
- [x] add labeling of compressed segment(s)
- [x] calculate compression metrics